### PR TITLE
Test ruby 3.4 and test for Rails.application

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ "3.2", "3.3" ]
+        ruby: [ "3.2", "3.3", "3.4" ]
     env:
       NOTIFY_APP_NAME: "ChatNotifier"
       NOTIFY_SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.4] - Unreleased
 
+### Changed
+
+- Add support for Ruby 3.4
+- Check for Rails application before using Rails.application
+
 ## [0.2.3] - 2024-09-21
 
 ### Fixed

--- a/lib/chat_notifier.rb
+++ b/lib/chat_notifier.rb
@@ -17,7 +17,7 @@ module ChatNotifier
     attr_accessor :logger
 
     def app
-      if defined?(::Rails)
+      if defined?(::Rails) && Rails.respond_to?(:application)
         Rails.application.class.module_parent
       else
         ENV.fetch("NOTIFY_APP_NAME")


### PR DESCRIPTION
When installed on systems using minitest, the plugin_chat_notifier_init would trigger accessing the Rails.application. This changes it to check if an application exists before attempting to access it.