### PR TITLE
Drop Ruby 3.2 (EOL) from CI and gemspec

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ "3.2", "3.3", "3.4" ]
+        ruby: [ "3.3", "3.4" ]
     env:
       NOTIFY_APP_NAME: "ChatNotifier"
       NOTIFY_SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/chat_notifier.gemspec
+++ b/chat_notifier.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
 
   spec.summary = "Notify chat of test results"
   spec.description = "Send test results to chat"
-  spec.required_ruby_version = ">= 3.2.0"
+  spec.required_ruby_version = ">= 3.3.0"
 
   spec.metadata["source_code_uri"] = "https://github.com/SOFware/chat_notifier.git"
   spec.metadata["changelog_uri"] = "https://github.com/SOFWare/chat_notifier/blob/master/CHANGELOG.md"


### PR DESCRIPTION
## Summary
- Remove Ruby 3.2 from the test matrix in `.github/workflows/test.yml`
- Bump `required_ruby_version` in `chat_notifier.gemspec` from `>= 3.2.0` to `>= 3.3.0`

## Business Justification
Ruby 3.2 reached end-of-life on 2025-03-31 and no longer receives security fixes. Continuing to test against it wastes CI minutes and signals support we don't actually want to offer. 3.3 is the oldest non-EOL line, so raising the floor there aligns chat_notifier with the rest of the SOFware gem fleet without cutting off any still-supported consumers.

## Technical Details
Nothing in the codebase depends on 3.2-specific behavior, so this is a metadata-only change.
