### PR TITLE
Add threaded Slack failure notifications

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,8 @@ jobs:
     env:
       NOTIFY_APP_NAME: "ChatNotifier"
       NOTIFY_SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      NOTIFY_SLACK_NOTIFY_CHANNEL: "oss-notices"
+      NOTIFY_SLACK_BOT_TOKEN: ${{ secrets.NOTIFY_SLACK_BOT_TOKEN }}
+      NOTIFY_SLACK_NOTIFY_CHANNEL: "C05985VPUSH" # #oss-notices
       NOTIFY_CURRENT_REPOSITORY_URL: "${{ github.server_url }}/${{ github.repository }}"
       NOTIFY_TEST_RUN_ID: "${{ github.run_id }}"
       CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         ruby: [ "3.3", "3.4", "4.0" ]
     env:
       NOTIFY_APP_NAME: "ChatNotifier"
-      NOTIFY_SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      NOTIFY_SLACK_WEBHOOK_URL: ${{ secrets.NOTIFY_SLACK_WEBHOOK_URL }}
       NOTIFY_SLACK_BOT_TOKEN: ${{ secrets.NOTIFY_SLACK_BOT_TOKEN }}
       NOTIFY_SLACK_NOTIFY_CHANNEL: "C05985VPUSH" # #oss-notices
       NOTIFY_CURRENT_REPOSITORY_URL: "${{ github.server_url }}/${{ github.repository }}"

--- a/README.md
+++ b/README.md
@@ -51,6 +51,22 @@ If you are _not_ using Rails, you will need to add this ENV variable:
       NOTIFY_APP_NAME
 ```
 
+### Threaded failure notifications (optional)
+
+Incoming webhooks post a single message. If you instead provide a Slack **bot
+token**, ChatNotifier uses the Slack Web API and threads failures: it posts the
+branch/run summary as a parent message, then posts the failing files — grouped
+into reasonably sized batches — as threaded replies.
+
+```
+      NOTIFY_SLACK_BOT_TOKEN        # xoxb-… bot token; enables threading
+      NOTIFY_SLACK_NOTIFY_CHANNEL   # channel id or name to post to
+      NOTIFY_SLACK_THREAD_GROUP_SIZE # optional, files per reply (default 10)
+```
+
+When both `NOTIFY_SLACK_BOT_TOKEN` and `NOTIFY_SLACK_WEBHOOK_URL` are set, the
+bot token is preferred. The bot needs the `chat:write` scope.
+
 ### Debug your Slack setup
 
 Create rake task to test the connection to your Slack channel

--- a/lib/chat_notifier/chatter/slack.rb
+++ b/lib/chat_notifier/chatter/slack.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
+require_relative "../failure_groups"
+
 module ChatNotifier
   class Chatter
     class Slack < self
       Chatter.register self
+
+      API_URL = "https://slack.com/api/chat.postMessage"
+      DEFAULT_THREAD_GROUP_SIZE = 10
 
       class << self
         def handles?(settings)
@@ -15,12 +20,69 @@ module ChatNotifier
         settings.fetch("NOTIFY_SLACK_WEBHOOK_URL", nil)
       end
 
+      def bot_token
+        settings.fetch("NOTIFY_SLACK_BOT_TOKEN", nil)
+      end
+
       def channel
         settings.fetch("NOTIFY_SLACK_NOTIFY_CHANNEL", nil)
       end
 
+      def thread_group_size
+        Integer(settings.fetch("NOTIFY_SLACK_THREAD_GROUP_SIZE", DEFAULT_THREAD_GROUP_SIZE))
+      end
+
+      # When a bot token is configured we use the Slack Web API, which can
+      # thread failures. The token path is preferred over an incoming webhook.
+      def post(messenger, process: Net::HTTP.method(:post))
+        return super unless bot_token
+
+        post_via_api(messenger, process:)
+      end
+
       def payload(data)
         super(Configuration.for(data, self).to_h)
+      end
+
+      private
+
+      def post_via_api(messenger, process:)
+        parent_text = messenger.failure? ? messenger.lede : messenger.message
+        parent = post_message(text: parent_text, process:)
+
+        return parent unless messenger.failure? && ok?(parent)
+
+        thread_ts = response_ts(parent)
+        FailureGroups.new(messenger.failures, group_size: thread_group_size).reply_texts.each do |text|
+          post_message(text:, thread_ts:, process:)
+        end
+      end
+
+      def post_message(text:, process:, thread_ts: nil)
+        body = {channel: channel, text: text}
+        body[:thread_ts] = thread_ts if thread_ts
+        process.call(URI(API_URL), body.to_json, api_headers)
+      end
+
+      def api_headers
+        {
+          "Content-Type" => "application/json; charset=utf-8",
+          "Authorization" => "Bearer #{bot_token}"
+        }
+      end
+
+      def ok?(response)
+        parsed_response(response)["ok"] == true
+      end
+
+      def response_ts(response)
+        parsed_response(response)["ts"]
+      end
+
+      def parsed_response(response)
+        JSON.parse(response.body.to_s)
+      rescue JSON::ParserError
+        {}
       end
 
       class Configuration

--- a/lib/chat_notifier/failure_groups.rb
+++ b/lib/chat_notifier/failure_groups.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module ChatNotifier
+  # Groups test failures by file and packs them into reasonably sized
+  # batches suitable for posting as individual Slack thread replies.
+  class FailureGroups
+    def initialize(failures, group_size: 10, char_limit: 3000)
+      @failures = failures
+      @group_size = group_size
+      @char_limit = char_limit
+    end
+
+    attr_reader :failures, :group_size, :char_limit
+
+    # One rendered string per thread reply: file blocks packed into batches
+    # bounded by group_size (file count) and char_limit (rendered length).
+    def reply_texts
+      batches.map { |blocks| blocks.join("\n") }
+    end
+
+    private
+
+    def batches
+      file_blocks.each_with_object([]) do |block, packed|
+        current = packed.last
+        if current.nil? ||
+            current.size >= group_size ||
+            (current.join("\n").length + 1 + block.length) > char_limit
+          packed << [block]
+        else
+          current << block
+        end
+      end
+    end
+
+    # Render each file (with its failing lines) into a text block.
+    def file_blocks
+      by_file.map do |file, lines|
+        bullets = lines.map { |line| "  • #{File.basename(file)}:#{line}" }
+        ([file] + bullets).join("\n")
+      end
+    end
+
+    # { "path/to/file.rb" => ["42", "88"], ... } preserving first-seen order.
+    def by_file
+      failures.each_with_object({}) do |failure, groups|
+        file, line = normalize(failure.location)
+        (groups[file] ||= []) << line
+      end
+    end
+
+    # RSpec locations are "path:line" strings; Minitest locations are
+    # [file, line] arrays. Normalize both to [file, line].
+    def normalize(location)
+      if location.is_a?(Array)
+        [location[0], location[1]]
+      else
+        file, _, line = location.to_s.rpartition(":")
+        [file, line]
+      end
+    end
+  end
+end

--- a/test/chatter/slack_test.rb
+++ b/test/chatter/slack_test.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "json"
 require "chat_notifier/chatter"
+
+FakeResponse = Struct.new(:body)
+MessengerDouble = Struct.new(:success?, :failure?, :lede, :message, :failures)
+FailureLoc = Struct.new(:location)
 
 describe ChatNotifier::Chatter::Slack do
   let(:settings) do
@@ -43,6 +48,102 @@ describe ChatNotifier::Chatter::Slack do
 
       it "returns a hash containing a success icon emoji" do
         expect(communicator.payload(messenger)).must_match(/:green_circle:/)
+      end
+    end
+  end
+
+  describe "#post with a bot token configured" do
+    let(:settings) do
+      {
+        "NOTIFY_SLACK_BOT_TOKEN" => "xoxb-test-token",
+        "NOTIFY_SLACK_NOTIFY_CHANNEL" => "#test",
+        "NOTIFY_SLACK_THREAD_GROUP_SIZE" => 1
+      }
+    end
+    let(:communicator) { ChatNotifier::Chatter::Slack.new(settings:, repository: nil, environment: nil) }
+
+    let(:messenger) do
+      MessengerDouble.new(
+        success?: false,
+        failure?: true,
+        lede: ":boom: failed in branch main",
+        message: "ignored",
+        failures: [
+          FailureLoc.new("test/a_test.rb:1"),
+          FailureLoc.new("test/b_test.rb:2")
+        ]
+      )
+    end
+
+    def record_calls
+      calls = []
+      process = lambda do |uri, body, headers = nil|
+        calls << {uri: uri.to_s, body: JSON.parse(body), headers: headers}
+        FakeResponse.new(%({"ok":true,"ts":"111.222"}))
+      end
+      yield process
+      calls
+    end
+
+    it "posts the parent message to the Web API with the bearer token" do
+      calls = record_calls { |process| communicator.post(messenger, process:) }
+
+      parent = calls.first
+      expect(parent[:uri]).must_equal("https://slack.com/api/chat.postMessage")
+      expect(parent[:headers]["Authorization"]).must_equal("Bearer xoxb-test-token")
+      expect(parent[:body]["text"]).must_equal(":boom: failed in branch main")
+      expect(parent[:body]["channel"]).must_equal("#test")
+      refute parent[:body].key?("thread_ts"), "parent must not be a threaded reply"
+    end
+
+    it "posts each failure group as a threaded reply using the parent ts" do
+      calls = record_calls { |process| communicator.post(messenger, process:) }
+
+      replies = calls.drop(1)
+      expect(replies.size).must_equal(2)
+      replies.each do |reply|
+        expect(reply[:body]["thread_ts"]).must_equal("111.222")
+      end
+      expect(replies[0][:body]["text"]).must_match(%r{test/a_test\.rb})
+      expect(replies[1][:body]["text"]).must_match(%r{test/b_test\.rb})
+    end
+
+    it "prefers the bot token over a configured webhook" do
+      settings["NOTIFY_SLACK_WEBHOOK_URL"] = "https://hooks.slack.com/abc/123"
+      calls = record_calls { |process| communicator.post(messenger, process:) }
+
+      expect(calls.first[:uri]).must_equal("https://slack.com/api/chat.postMessage")
+    end
+
+    it "does not post replies when the parent message fails" do
+      calls = []
+      process = lambda do |uri, body, headers = nil|
+        calls << uri.to_s
+        FakeResponse.new(%({"ok":false,"error":"channel_not_found"}))
+      end
+
+      communicator.post(messenger, process:)
+
+      expect(calls.size).must_equal(1)
+    end
+
+    describe "when the run succeeds" do
+      let(:messenger) do
+        MessengerDouble.new(
+          success?: true,
+          failure?: false,
+          lede: "ignored",
+          message: ":thumbsup: all good",
+          failures: []
+        )
+      end
+
+      it "posts a single non-threaded message via the Web API" do
+        calls = record_calls { |process| communicator.post(messenger, process:) }
+
+        expect(calls.size).must_equal(1)
+        expect(calls.first[:body]["text"]).must_equal(":thumbsup: all good")
+        refute calls.first[:body].key?("thread_ts")
       end
     end
   end

--- a/test/failure_groups_test.rb
+++ b/test/failure_groups_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "chat_notifier/failure_groups"
+
+Loc = Struct.new(:location)
+
+describe ChatNotifier::FailureGroups do
+  describe "#reply_texts" do
+    it "groups failures in the same file under one heading" do
+      failures = [
+        Loc.new("test/models/user_test.rb:42"),
+        Loc.new("test/models/user_test.rb:88")
+      ]
+
+      texts = ChatNotifier::FailureGroups.new(failures).reply_texts
+
+      expect(texts.size).must_equal(1)
+      expect(texts.first).must_equal(<<~TEXT.chomp)
+        test/models/user_test.rb
+          • user_test.rb:42
+          • user_test.rb:88
+      TEXT
+    end
+
+    it "splits files into separate replies once the group size is exceeded" do
+      failures = (1..5).map { |n| Loc.new("test/file_#{n}_test.rb:#{n}") }
+
+      texts = ChatNotifier::FailureGroups.new(failures, group_size: 2).reply_texts
+
+      expect(texts.size).must_equal(3)
+      expect(texts[0]).must_equal("test/file_1_test.rb\n  • file_1_test.rb:1\ntest/file_2_test.rb\n  • file_2_test.rb:2")
+      expect(texts[2]).must_equal("test/file_5_test.rb\n  • file_5_test.rb:5")
+    end
+
+    it "normalizes Minitest [file, line] array locations" do
+      failures = [Loc.new(["test/order_test.rb", 13])]
+
+      texts = ChatNotifier::FailureGroups.new(failures).reply_texts
+
+      expect(texts.first).must_equal("test/order_test.rb\n  • order_test.rb:13")
+    end
+
+    it "starts a new reply when adding a file would exceed the char limit" do
+      failures = [
+        Loc.new("test/a_test.rb:1"),
+        Loc.new("test/b_test.rb:2")
+      ]
+
+      texts = ChatNotifier::FailureGroups.new(failures, char_limit: 30).reply_texts
+
+      expect(texts.size).must_equal(2)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

When a Slack **bot token** is configured, test-run failures are posted to the Slack Web API (`chat.postMessage`) as a **threaded conversation** instead of a single message:

- A **parent message** carries the branch/run summary (`:boom: <app> <ruby> <sha> has failed N times! in <branch>` + the run URL).
- The **failing files are grouped** and posted as **threaded replies**, batched to a reasonable size (default 10 files per reply, also split under Slack's ~3000-char block limit).

Configuration:

- `NOTIFY_SLACK_BOT_TOKEN` — `xoxb-…` token; enables threading (needs `chat:write`)
- `NOTIFY_SLACK_NOTIFY_CHANNEL` — channel to post to (reused)
- `NOTIFY_SLACK_THREAD_GROUP_SIZE` — optional, files per reply (default 10)

When both a bot token and an incoming webhook are configured, the **bot token is preferred**. Webhook-only setups are completely unchanged.

## Implementation notes

- New `ChatNotifier::FailureGroups` normalizes failure locations (RSpec `"path:line"` strings and Minitest `[file, line]` arrays), groups by file, and packs files into batched reply texts.
- `Chatter::Slack#post` branches to the Web API path when a token is present; the parent post is read for its `ts`, and replies are posted with `thread_ts`. If the parent fails or returns `ok: false`, replies are skipped (no orphan thread).
- Replies list file locations only — that's all the gem currently captures per failure (richer per-failure context is a separate roadmap item).

Draft pending review of the threading UX in a real channel.