### PR TITLE
Update dependencies and adopt reissue 0.5 release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,3 +10,4 @@ jobs:
       git_user_email: 'gems@sofwarellc.com'
       git_user_name: 'SOFware'
       ruby_version: '3.4'
+      generate_checksum: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,12 +8,11 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
-    date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
     drb (2.2.3)
-    erb (6.0.4)
+    erb (6.0.6)
     io-console (0.8.2)
     irb (1.18.0)
       pp (>= 0.6.0)
@@ -32,22 +31,24 @@ GEM
     parser (3.3.12.0)
       ast (~> 2.4.1)
       racc
-    pp (0.6.3)
+    pp (0.6.4)
       prettyprint
     prettyprint (0.2.0)
     prism (1.9.0)
-    psych (5.4.0)
-      date
-      stringio
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.4.2)
-    rdoc (7.2.0)
+    rbs (4.0.3)
+      logger
+      prism (>= 1.6.0)
+      tsort
+    rdoc (8.0.0)
       erb
-      psych (>= 4.0.0)
+      prism (>= 1.6.0)
+      rbs (>= 4.0.0)
       tsort
     regexp_parser (2.12.0)
-    reissue (0.4.22)
+    reissue (0.5.1)
       rake
     reline (0.6.3)
       io-console (~> 0.5)
@@ -86,7 +87,6 @@ GEM
     standard-performance (1.9.0)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.26.0)
-    stringio (3.2.0)
     tsort (0.2.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)

--- a/Rakefile
+++ b/Rakefile
@@ -15,5 +15,5 @@ require "reissue/gem"
 
 Reissue::Task.create :reissue do |task|
   task.version_file = "lib/chat_notifier/version.rb"
-  task.push_finalize = :branch
+  task.fragment = :git
 end


### PR DESCRIPTION
## Summary

Updates dependencies and aligns the release setup with the newer reissue gem and its shared GitHub Actions release workflow.

- **Bump reissue 0.4.22 → 0.5.1** (and transitive gems: `erb`, `pp`, `rdoc`, plus new `rbs`) via `bundle update`.
- **Read changelog entries and version bumps from git commit trailers** (`task.fragment = :git`), replacing `push_finalize = :branch`. That old setting pushed a branch mid-release (during changelog finalize, before the gem was built/tagged); the shared workflow's default `push_reissue = :branch` now handles the post-release branch/PR instead.
- **Opt into checksum generation** in the shared release workflow (`generate_checksum: true`) so releases build with `rake build:checksum release` and commit a SHA512 into `checksums/`.

## Verification

- `bundle check` — dependencies satisfied
- `rake test` — 31 runs, 46 assertions, 0 failures
- `standardrb Rakefile` — clean
- `rake reissue:preview` — correctly picks up the existing `Added:`/`Version:` trailers from prior commits
- `rake reissue:next_version` — returns `0.3.0` (applies the `Version: minor` trailer to the current `0.2.6`), confirming the shared workflow's dry-run path works with 0.5.1