### PR TITLE
Finalize release on a branch to avoid pushing to protected main

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,4 +16,5 @@ require "reissue/gem"
 Reissue::Task.create :reissue do |task|
   task.version_file = "lib/chat_notifier/version.rb"
   task.fragment = :git
+  task.push_finalize = :branch
 end


### PR DESCRIPTION
The 0.3.0 release ([run](https://github.com/SOFware/chat_notifier/actions/runs/30094667475)) failed at bundler's `release:source_control_push`, which pushes the current branch — `main` — directly. `main` is protected (requires PR + the "Ruby 4.0" check), so the push was rejected. It built the gem and wrote the checksum but failed **before** `release:rubygem_push`, so nothing was published.

Root cause: PR #79 dropped `push_finalize = :branch`. With it set, `reissue:finalize` checks out `finalize/<version>` before bundler's release push, so the push never targets `main`. The tag and RubyGems publish still happen; the post-release version bump lands via PR.

This restores it, matching reissue's own Rakefile, which releases reissue itself through the same shared workflow against a protected `main`.