### PR TITLE
Make Slack notification delivery observable and resilient

### DIFF
--- a/lib/chat_notifier.rb
+++ b/lib/chat_notifier.rb
@@ -70,7 +70,7 @@ module ChatNotifier
       chatter.each do |box|
         box.conditional_post(messenger)
       rescue => exception
-        logger.error("ChatNotifier: #{box.webhook_url} #{exception.class}: #{exception.message}")
+        logger.error("ChatNotifier: #{box.class} #{exception.class}: #{exception.message}")
       end
     end
   end

--- a/lib/chat_notifier/chatter.rb
+++ b/lib/chat_notifier/chatter.rb
@@ -7,6 +7,9 @@ require "json"
 module ChatNotifier
   # All behavior for interacting with a notification platform
   class Chatter
+    OPEN_TIMEOUT = 5
+    READ_TIMEOUT = 10
+
     def initialize(settings:, repository:, environment:)
       @settings = settings
       @repository = repository
@@ -45,16 +48,30 @@ module ChatNotifier
     def body
     end
 
-    def post(messenger, process: Net::HTTP.method(:post))
+    def post(messenger, process: method(:http_post))
       uri = URI(webhook_url)
 
       process.call(uri, payload(messenger))
     end
 
-    def conditional_post(messenger, process: Net::HTTP.method(:post))
+    def conditional_post(messenger, process: method(:http_post))
       return if messenger.success? && !verbose?
 
       post(messenger, process:)
+    end
+
+    def http_client(uri)
+      Net::HTTP.new(uri.host, uri.port).tap do |http|
+        http.use_ssl = uri.scheme == "https"
+        http.open_timeout = OPEN_TIMEOUT
+        http.read_timeout = READ_TIMEOUT
+      end
+    end
+
+    def http_post(uri, body, headers = nil)
+      http_client(uri).start do |http|
+        http.request_post(uri.request_uri, body, headers)
+      end
     end
 
     def verbose?

--- a/lib/chat_notifier/chatter/slack.rb
+++ b/lib/chat_notifier/chatter/slack.rb
@@ -12,7 +12,9 @@ module ChatNotifier
 
       class << self
         def handles?(settings)
-          !settings.keys.grep(/NOTIFY_SLACK/).empty?
+          %w[NOTIFY_SLACK_WEBHOOK_URL NOTIFY_SLACK_BOT_TOKEN].any? do |key|
+            settings.fetch(key, nil)
+          end
         end
       end
 
@@ -30,11 +32,20 @@ module ChatNotifier
 
       def thread_group_size
         Integer(settings.fetch("NOTIFY_SLACK_THREAD_GROUP_SIZE", DEFAULT_THREAD_GROUP_SIZE))
+      rescue ArgumentError, TypeError
+        DEFAULT_THREAD_GROUP_SIZE
+      end
+
+      # Injectable pause used when Slack rate-limits a post.
+      attr_writer :sleeper
+
+      def sleeper
+        @sleeper ||= Kernel.method(:sleep)
       end
 
       # When a bot token is configured we use the Slack Web API, which can
       # thread failures. The token path is preferred over an incoming webhook.
-      def post(messenger, process: Net::HTTP.method(:post))
+      def post(messenger, process: method(:http_post))
         return super unless bot_token
 
         post_via_api(messenger, process:)
@@ -53,6 +64,8 @@ module ChatNotifier
         return parent unless messenger.failure? && ok?(parent)
 
         thread_ts = response_ts(parent)
+        return parent unless thread_ts
+
         FailureGroups.new(messenger.failures, group_size: thread_group_size).reply_texts.each do |text|
           post_message(text:, thread_ts:, process:)
         end
@@ -61,7 +74,33 @@ module ChatNotifier
       def post_message(text:, process:, thread_ts: nil)
         body = {channel: channel, text: text}
         body[:thread_ts] = thread_ts if thread_ts
-        process.call(URI(API_URL), body.to_json, api_headers)
+        deliver = -> { process.call(URI(API_URL), body.to_json, api_headers) }
+
+        response = deliver.call
+        if rate_limited?(response)
+          sleeper.call(retry_after(response))
+          response = deliver.call
+        end
+        log_api_error(response)
+        response
+      end
+
+      def rate_limited?(response)
+        response.respond_to?(:code) && response.code.to_s == "429"
+      end
+
+      def retry_after(response)
+        Integer(response["Retry-After"])
+      rescue ArgumentError, TypeError
+        1
+      end
+
+      def log_api_error(response)
+        parsed = parsed_response(response)
+        return if parsed["ok"] == true
+
+        error = parsed.fetch("error", "unrecognized response")
+        ChatNotifier.logger.error("ChatNotifier: Slack API error: #{error}")
       end
 
       def api_headers

--- a/test/chat_notifier_test.rb
+++ b/test/chat_notifier_test.rb
@@ -138,5 +138,44 @@ module ChatNotifier
         ENV["NOTIFY_APP_NAME"] = original_app_name
       end
     end
+
+    def test_call_logs_errors_without_leaking_the_webhook_url
+      original_app_name = ENV["NOTIFY_APP_NAME"]
+      ENV["NOTIFY_APP_NAME"] = "TestApp"
+
+      test_box = Object.new
+      def test_box.webhook_url = "https://hooks.slack.com/services/SECRET/TOKEN"
+
+      def test_box.conditional_post(messenger)
+        raise "boom"
+      end
+
+      factory = ->(value) {
+        f = Class.new
+        f.define_singleton_method(:for) { |*, **| value }
+        f
+      }
+      chatter_factory = Class.new
+      chatter_factory.define_singleton_method(:handling) { |env, repository:, environment:| [test_box] }
+
+      logged = capture_logs do
+        ChatNotifier.call(
+          summary: @summary,
+          repository: factory.call(Object.new),
+          environment: factory.call(Object.new),
+          chatter: chatter_factory,
+          messenger: factory.call(Object.new)
+        )
+      end
+
+      assert_match(/RuntimeError: boom/, logged)
+      refute_match(/hooks\.slack\.com/, logged, "webhook URL is a credential and must not be logged")
+    ensure
+      if original_app_name.nil?
+        ENV.delete("NOTIFY_APP_NAME")
+      else
+        ENV["NOTIFY_APP_NAME"] = original_app_name
+      end
+    end
   end
 end

--- a/test/chatter/slack_test.rb
+++ b/test/chatter/slack_test.rb
@@ -5,6 +5,9 @@ require "json"
 require "chat_notifier/chatter"
 
 FakeResponse = Struct.new(:body)
+RateLimitedResponse = Struct.new(:body, :code, :headers) do
+  def [](key) = headers[key]
+end
 MessengerDouble = Struct.new(:success?, :failure?, :lede, :message, :failures)
 FailureLoc = Struct.new(:location)
 
@@ -28,6 +31,34 @@ describe ChatNotifier::Chatter::Slack do
 
       it "returns false" do
         refute ChatNotifier::Chatter::Slack.handles?(settings), "Expected #{ChatNotifier::Chatter::Slack} not to handle #{settings.inspect}"
+      end
+    end
+
+    describe "when settings has NOTIFY_SLACK keys but no webhook or bot token" do
+      let(:settings) { {"NOTIFY_SLACK_THREAD_GROUP_SIZE" => "5"} }
+
+      it "returns false" do
+        refute ChatNotifier::Chatter::Slack.handles?(settings), "Expected #{ChatNotifier::Chatter::Slack} not to handle settings with no credential"
+      end
+    end
+
+    describe "when settings has only a bot token" do
+      let(:settings) { {"NOTIFY_SLACK_BOT_TOKEN" => "xoxb-123"} }
+
+      it "returns true" do
+        assert ChatNotifier::Chatter::Slack.handles?(settings), "Expected #{ChatNotifier::Chatter::Slack} to handle bot-token settings"
+      end
+    end
+  end
+
+  describe "#thread_group_size" do
+    let(:communicator) { ChatNotifier::Chatter::Slack.new(settings:, repository: nil, environment: nil) }
+
+    describe "when the setting is not a number" do
+      let(:settings) { {"NOTIFY_SLACK_THREAD_GROUP_SIZE" => "lots"} }
+
+      it "falls back to the default" do
+        expect(communicator.thread_group_size).must_equal(ChatNotifier::Chatter::Slack::DEFAULT_THREAD_GROUP_SIZE)
       end
     end
   end
@@ -125,6 +156,61 @@ describe ChatNotifier::Chatter::Slack do
       communicator.post(messenger, process:)
 
       expect(calls.size).must_equal(1)
+    end
+
+    it "does not post replies when the parent response has no ts" do
+      calls = []
+      process = lambda do |uri, body, headers = nil|
+        calls << uri.to_s
+        FakeResponse.new(%({"ok":true}))
+      end
+
+      communicator.post(messenger, process:)
+
+      expect(calls.size).must_equal(1)
+    end
+
+    it "logs the Slack error when the parent message fails" do
+      process = ->(uri, body, headers = nil) { FakeResponse.new(%({"ok":false,"error":"channel_not_found"})) }
+
+      logged = capture_logs { communicator.post(messenger, process:) }
+
+      expect(logged).must_match(/channel_not_found/)
+    end
+
+    it "logs the Slack error when a threaded reply fails" do
+      responses = [
+        FakeResponse.new(%({"ok":true,"ts":"111.222"})),
+        FakeResponse.new(%({"ok":false,"error":"ratelimited"}))
+      ]
+      process = ->(uri, body, headers = nil) { responses.shift || FakeResponse.new(%({"ok":true,"ts":"333.444"})) }
+
+      logged = capture_logs { communicator.post(messenger, process:) }
+
+      expect(logged).must_match(/ratelimited/)
+    end
+
+    it "retries once after the Retry-After delay when rate limited" do
+      rate_limited = RateLimitedResponse.new(%({"ok":false,"error":"ratelimited"}), "429", {"Retry-After" => "7"})
+      responses = [
+        FakeResponse.new(%({"ok":true,"ts":"111.222"})),
+        rate_limited,
+        FakeResponse.new(%({"ok":true,"ts":"111.222"}))
+      ]
+      bodies = []
+      process = lambda do |uri, body, headers = nil|
+        bodies << JSON.parse(body)
+        responses.shift || FakeResponse.new(%({"ok":true,"ts":"111.222"}))
+      end
+      slept = []
+      communicator.sleeper = ->(seconds) { slept << seconds }
+
+      communicator.post(messenger, process:)
+
+      expect(slept).must_equal([7])
+      # parent + first reply + its retry + second reply
+      expect(bodies.size).must_equal(4)
+      expect(bodies[1]["text"]).must_equal(bodies[2]["text"])
     end
 
     describe "when the run succeeds" do

--- a/test/chatter_test.rb
+++ b/test/chatter_test.rb
@@ -7,6 +7,23 @@ describe ChatNotifier::Chatter do
   let(:repository) { Object.new }
   let(:environment) { Object.new }
 
+  describe "#http_client" do
+    let(:chatter) { ChatNotifier::Chatter.new(settings: {}, repository:, environment:) }
+
+    it "configures short timeouts so notifications cannot hang the test run" do
+      client = chatter.http_client(URI("https://slack.com/api/chat.postMessage"))
+
+      expect(client.open_timeout).must_equal(ChatNotifier::Chatter::OPEN_TIMEOUT)
+      expect(client.read_timeout).must_equal(ChatNotifier::Chatter::READ_TIMEOUT)
+    end
+
+    it "uses SSL for https URIs" do
+      client = chatter.http_client(URI("https://slack.com/api/chat.postMessage"))
+
+      assert client.use_ssl?, "expected SSL to be enabled for https"
+    end
+  end
+
   describe "#verbose?" do
     describe "when NOTIFIER_VERBOSE is not set" do
       it "returns false" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,6 +19,17 @@ end
 require "minitest/autorun"
 require "minitest/mock"
 
+def capture_logs
+  require "stringio"
+  io = StringIO.new
+  original = ChatNotifier.logger
+  ChatNotifier.logger = Logger.new(io)
+  yield
+  io.string
+ensure
+  ChatNotifier.logger = original
+end
+
 def mimic(**kwargs)
   m = Minitest::Mock.new
   kwargs.each do |method_name, return_value|


### PR DESCRIPTION
## Summary

Fixes six reliability issues in the Slack notification path, found while reviewing the threaded-notifications implementation. All changes were test-driven.

### Fixed
- **Silent API failures**: Slack returns HTTP 200 with `ok: false` for most real errors (`invalid_auth`, `channel_not_found`, `not_in_channel`). These were invisible — the parent check only decided whether to thread, and reply responses were ignored entirely. Every API response is now checked and failures are logged.
- **Credential leak in error logs**: `ChatNotifier.call` logged `box.webhook_url` on error — a Slack webhook URL is a secret and this put it in CI logs. Now logs the chatter class name.
- **Overeager handler activation**: any `NOTIFY_SLACK*` key (e.g. only `NOTIFY_SLACK_THREAD_GROUP_SIZE`) activated the Slack handler with no credentials, producing a `URI(nil)` error every run. Now requires a webhook URL or bot token. The Debug chatter has its own `handles?` and is unaffected.
- **Malformed `NOTIFY_SLACK_THREAD_GROUP_SIZE`** raised at exit; now falls back to the default.
- **Missing `ts` guard**: a parent response without `ts` caused replies to post as top-level messages — the exact noise threading exists to prevent. Replies are now skipped.

### Added
- **Rate-limit handling**: `chat.postMessage` allows ~1 msg/sec/channel; batched replies could draw 429s and be silently dropped. Rate-limited posts now retry once, honoring `Retry-After` (injectable sleeper for tests).
- **HTTP timeouts**: the default `Net::HTTP.post` waits 60s open + 60s read — per message, at test-suite exit. Both webhook and API paths now use an explicit 5s open / 10s read transport.