### PR TITLE
One Slack thread per breakage episode with live status digest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+.worktrees/

--- a/README.md
+++ b/README.md
@@ -67,6 +67,34 @@ into reasonably sized batches — as threaded replies.
 When both `NOTIFY_SLACK_BOT_TOKEN` and `NOTIFY_SLACK_WEBHOOK_URL` are set, the
 bot token is preferred. The bot needs the `chat:write` scope.
 
+### Episode threading (bot token only)
+
+With a bot token, ChatNotifier keeps **one thread per breakage episode** on a
+branch/PR — shared across parallel CI jobs (matrix builds). Parent messages
+carry message metadata; each job finds the episode thread by scanning channel
+history, so no shared storage is needed. The parent is a live status digest
+updated as each job reports (e.g. `test ruby-3.2 ❌ 12 · test ruby-3.3 ✅`) and
+flips to ✅ resolved when the latest run is all green. Passing runs post
+nothing unless they resolve a known open episode.
+
+```
+      NOTIFY_THREAD_STORE           # set to "none" to opt out of episode threading
+      NOTIFY_JOB_NAME               # optional job identity (default: GITHUB_JOB + ruby version)
+```
+
+`GITHUB_RUN_ATTEMPT` is picked up automatically, so "Re-run failed jobs"
+supersedes earlier attempts in the digest.
+
+In addition to `chat:write`, the bot needs `channels:history` (and
+`groups:history` for private channels) to find episode threads. Missing scopes
+degrade gracefully: the lookup logs an error and each job falls back to its
+own thread.
+
+Caveats: verbose mode (`NOTIFIER_VERBOSE`) posts plain messages and bypasses
+episode resolution, and a thread store passed programmatically
+(`ChatNotifier.call(thread_store: ...)`) takes precedence over
+`NOTIFY_THREAD_STORE=none`.
+
 ### Debug your Slack setup
 
 Create rake task to test the connection to your Slack channel

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ into reasonably sized batches — as threaded replies.
 
 ```
       NOTIFY_SLACK_BOT_TOKEN        # xoxb-… bot token; enables threading
-      NOTIFY_SLACK_NOTIFY_CHANNEL   # channel id or name to post to
+      NOTIFY_SLACK_NOTIFY_CHANNEL   # channel ID (C…) — required for episode threading; a #name only posts
       NOTIFY_SLACK_THREAD_GROUP_SIZE # optional, files per reply (default 10)
 ```
 
@@ -86,9 +86,12 @@ nothing unless they resolve a known open episode.
 supersedes earlier attempts in the digest.
 
 In addition to `chat:write`, the bot needs `channels:history` (and
-`groups:history` for private channels) to find episode threads. Missing scopes
-degrade gracefully: the lookup logs an error and each job falls back to its
-own thread.
+`groups:history` for private channels) to find episode threads, and it must be
+a **member of the channel** (`/invite @YourBot`). Use the channel **ID** in
+`NOTIFY_SLACK_NOTIFY_CHANNEL`: posting accepts a `#name`, but the history
+lookup does not, so a name degrades to per-job threads. Missing scopes or
+membership degrade gracefully: the lookup logs an error and each job falls
+back to its own thread.
 
 Caveats: verbose mode (`NOTIFIER_VERBOSE`) posts plain messages and bypasses
 episode resolution, and a thread store passed programmatically

--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ own thread.
 Caveats: verbose mode (`NOTIFIER_VERBOSE`) posts plain messages and bypasses
 episode resolution, and a thread store passed programmatically
 (`ChatNotifier.call(thread_store: ...)`) takes precedence over
-`NOTIFY_THREAD_STORE=none`.
+`NOTIFY_THREAD_STORE=none`. A single CI job running both RSpec and Minitest
+posts two status reports under the same job identity and only the earliest per
+run counts in the digest — set `NOTIFY_JOB_NAME` per framework to disambiguate.
 
 ### Debug your Slack setup
 

--- a/lib/chat_notifier.rb
+++ b/lib/chat_notifier.rb
@@ -61,6 +61,10 @@ module ChatNotifier
         environment:
       )
 
+      if (store = kwargs[:thread_store])
+        chatter.each { |box| box.thread_store = store }
+      end
+
       messenger = (kwargs[:messenger] || STANDARDS[:messenger]).for(
         summary,
         app:,

--- a/lib/chat_notifier.rb
+++ b/lib/chat_notifier.rb
@@ -2,6 +2,7 @@
 
 require_relative "chat_notifier/version"
 
+require_relative "chat_notifier/app"
 require_relative "chat_notifier/messenger"
 require_relative "chat_notifier/thread_store"
 require_relative "chat_notifier/repository"
@@ -44,7 +45,7 @@ module ChatNotifier
       )
       messenger = (kwargs[:messenger] || STANDARDS[:messenger]).for(
         summary,
-        app:,
+        app: App.new(name: app(env:), settings: env),
         repository:,
         environment:
       )
@@ -67,7 +68,7 @@ module ChatNotifier
 
       messenger = (kwargs[:messenger] || STANDARDS[:messenger]).for(
         summary,
-        app:,
+        app: App.new(name: app, settings: ENV),
         repository:,
         environment:
       )

--- a/lib/chat_notifier.rb
+++ b/lib/chat_notifier.rb
@@ -3,6 +3,7 @@
 require_relative "chat_notifier/version"
 
 require_relative "chat_notifier/messenger"
+require_relative "chat_notifier/thread_store"
 require_relative "chat_notifier/repository"
 require_relative "chat_notifier/test_environment"
 require_relative "chat_notifier/chatter"

--- a/lib/chat_notifier/app.rb
+++ b/lib/chat_notifier/app.rb
@@ -4,12 +4,13 @@ module ChatNotifier
   # The application under test: its name plus the source control context
   # (branch and sha), resolved from CI-standard settings with git fallbacks.
   class App
-    def initialize(name:, settings:)
+    def initialize(name:, settings:, runner: method(:capture))
       @name = name
       @settings = settings
+      @runner = runner
     end
 
-    attr_reader :name, :settings
+    attr_reader :name, :settings, :runner
 
     def to_s = name
 
@@ -38,10 +39,14 @@ module ChatNotifier
     end
 
     def git(command)
-      value = `git #{command} 2>/dev/null`.chomp
+      value = runner.call("git #{command}").to_s.chomp
       value.empty? ? nil : value
     rescue
       nil
+    end
+
+    def capture(command)
+      `#{command} 2>/dev/null`
     end
   end
 end

--- a/lib/chat_notifier/app.rb
+++ b/lib/chat_notifier/app.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module ChatNotifier
+  # The application under test: its name plus the source control context
+  # (branch and sha), resolved from CI-standard settings with git fallbacks.
+  class App
+    def initialize(name:, settings:)
+      @name = name
+      @settings = settings
+    end
+
+    attr_reader :name, :settings
+
+    def to_s = name
+
+    def branch
+      return @branch if defined?(@branch)
+
+      @branch = from_settings("NOTIFY_BRANCH", "GITHUB_HEAD_REF", "GITHUB_REF_NAME") ||
+        git("branch --show-current")
+    end
+
+    def sha
+      return @sha if defined?(@sha)
+
+      @sha = from_settings("NOTIFY_SHA", "GITHUB_SHA") ||
+        git("rev-parse --short HEAD")
+    end
+
+    private
+
+    def from_settings(*keys)
+      keys.each do |key|
+        value = settings[key]
+        return value unless value.nil? || value.empty?
+      end
+      nil
+    end
+
+    def git(command)
+      value = `git #{command} 2>/dev/null`.chomp
+      value.empty? ? nil : value
+    rescue
+      nil
+    end
+  end
+end

--- a/lib/chat_notifier/chatter.rb
+++ b/lib/chat_notifier/chatter.rb
@@ -4,6 +4,8 @@ require "net/http"
 require "uri"
 require "json"
 
+require_relative "thread_store"
+
 module ChatNotifier
   # All behavior for interacting with a notification platform
   class Chatter
@@ -76,6 +78,17 @@ module ChatNotifier
 
     def verbose?
       !!settings.fetch("NOTIFIER_VERBOSE", false)
+    end
+
+    # Injectable store mapping thread keys to existing chat threads.
+    attr_writer :thread_store
+
+    def thread_store
+      @thread_store ||= default_thread_store
+    end
+
+    def default_thread_store
+      ThreadStore::Null.new
     end
 
     def payload(data)

--- a/lib/chat_notifier/chatter.rb
+++ b/lib/chat_notifier/chatter.rb
@@ -84,7 +84,11 @@ module ChatNotifier
     attr_writer :thread_store
 
     def thread_store
-      @thread_store ||= default_thread_store
+      @thread_store ||= if settings.fetch("NOTIFY_THREAD_STORE", nil) == "none"
+        ThreadStore::Null.new
+      else
+        default_thread_store
+      end
     end
 
     def default_thread_store

--- a/lib/chat_notifier/chatter/slack.rb
+++ b/lib/chat_notifier/chatter/slack.rb
@@ -8,6 +8,8 @@ module ChatNotifier
       Chatter.register self
 
       API_URL = "https://slack.com/api/chat.postMessage"
+      REPLIES_URL = "https://slack.com/api/conversations.replies"
+      UPDATE_URL = "https://slack.com/api/chat.update"
       DEFAULT_THREAD_GROUP_SIZE = 10
       STATUS_EVENT_TYPE = "chat_notifier_status"
 
@@ -92,6 +94,27 @@ module ChatNotifier
 
         post_message(text: status_text(messenger), thread_ts:, process:,
           metadata: {event_type: STATUS_EVENT_TYPE, event_payload: messenger.status_report})
+
+        update_parent(messenger, thread_ts, process:)
+      end
+
+      # The parent message is a materialized view of the thread: refetch the
+      # status replies and recompute its text and status via chat.update.
+      def update_parent(messenger, thread_ts, process:)
+        replies = api_form_post(REPLIES_URL,
+          {channel: channel, ts: thread_ts, include_all_metadata: true, limit: 200}, process:)
+        return unless replies["ok"]
+
+        reports = (replies["messages"] || []).filter_map do |message|
+          message.dig("metadata", "event_payload") if message.dig("metadata", "event_type") == STATUS_EVENT_TYPE
+        end
+        return if reports.empty?
+
+        status = messenger.resolved?(reports) ? "resolved" : "failing"
+        body = {channel: channel, ts: thread_ts, text: messenger.digest(reports),
+                metadata: {event_type: ThreadStore::SlackMetadata::EVENT_TYPE,
+                           event_payload: {key: messenger.thread_key, status: status}}}
+        log_api_error(process.call(URI(UPDATE_URL), body.to_json, api_headers))
       end
 
       def status_text(messenger)

--- a/lib/chat_notifier/chatter/slack.rb
+++ b/lib/chat_notifier/chatter/slack.rb
@@ -62,25 +62,43 @@ module ChatNotifier
         parsed_response(response)
       end
 
+      # With a bot token the channel itself can store thread metadata.
+      def default_thread_store
+        return super unless bot_token
+
+        ThreadStore::SlackMetadata.new(chatter: self)
+      end
+
       private
 
       def post_via_api(messenger, process:)
-        parent_text = messenger.failure? ? messenger.lede : messenger.message
-        parent = post_message(text: parent_text, process:)
+        return post_message(text: messenger.message, process:) unless messenger.failure?
 
-        return parent unless messenger.failure? && ok?(parent)
+        key = messenger.thread_key
+        ref = thread_store.find(key)
+        thread_ts = ref&.open? ? ref.ts : nil
 
-        thread_ts = response_ts(parent)
-        return parent unless thread_ts
+        unless thread_ts
+          parent = post_message(text: messenger.lede, process:, metadata: parent_metadata(key))
+          return parent unless ok?(parent)
+          thread_ts = response_ts(parent)
+          return parent unless thread_ts
+        end
 
         FailureGroups.new(messenger.failures, group_size: thread_group_size).reply_texts.each do |text|
           post_message(text:, thread_ts:, process:)
         end
       end
 
-      def post_message(text:, process:, thread_ts: nil)
+      def parent_metadata(key)
+        {event_type: ThreadStore::SlackMetadata::EVENT_TYPE,
+         event_payload: {key: key, status: "failing"}}
+      end
+
+      def post_message(text:, process:, thread_ts: nil, metadata: nil)
         body = {channel: channel, text: text}
         body[:thread_ts] = thread_ts if thread_ts
+        body[:metadata] = metadata if metadata
         deliver = -> { process.call(URI(API_URL), body.to_json, api_headers) }
 
         response = deliver.call

--- a/lib/chat_notifier/chatter/slack.rb
+++ b/lib/chat_notifier/chatter/slack.rb
@@ -100,10 +100,16 @@ module ChatNotifier
 
       # The parent message is a materialized view of the thread: refetch the
       # status replies and recompute its text and status via chat.update.
+      # Fetch and update are not atomic (Slack has no compare-and-set), so a
+      # concurrent job can win the last write; the next event repairs it.
       def update_parent(messenger, thread_ts, process:)
         replies = api_form_post(REPLIES_URL,
-          {channel: channel, ts: thread_ts, include_all_metadata: true, limit: 200}, process:)
+          {channel: channel, ts: thread_ts, include_all_metadata: true, limit: 1000}, process:)
         return unless replies["ok"]
+
+        if replies["has_more"]
+          ChatNotifier.logger.warn("ChatNotifier: thread replies truncated; parent digest may be stale")
+        end
 
         reports = (replies["messages"] || []).filter_map do |message|
           message.dig("metadata", "event_payload") if message.dig("metadata", "event_type") == STATUS_EVENT_TYPE

--- a/lib/chat_notifier/chatter/slack.rb
+++ b/lib/chat_notifier/chatter/slack.rb
@@ -55,6 +55,13 @@ module ChatNotifier
         super(Configuration.for(data, self).to_h)
       end
 
+      # Slack read APIs (conversations.history, conversations.replies) take
+      # form-encoded params rather than JSON bodies.
+      def api_form_post(url, params, process: method(:http_post))
+        response = process.call(URI(url), URI.encode_www_form(params), form_headers)
+        parsed_response(response)
+      end
+
       private
 
       def post_via_api(messenger, process:)
@@ -106,6 +113,13 @@ module ChatNotifier
       def api_headers
         {
           "Content-Type" => "application/json; charset=utf-8",
+          "Authorization" => "Bearer #{bot_token}"
+        }
+      end
+
+      def form_headers
+        {
+          "Content-Type" => "application/x-www-form-urlencoded",
           "Authorization" => "Bearer #{bot_token}"
         }
       end

--- a/lib/chat_notifier/chatter/slack.rb
+++ b/lib/chat_notifier/chatter/slack.rb
@@ -54,6 +54,13 @@ module ChatNotifier
         post_via_api(messenger, process:)
       end
 
+      def conditional_post(messenger, process: method(:http_post))
+        return super unless bot_token
+        return post(messenger, process:) if messenger.failure? || verbose?
+
+        resolve_episode(messenger, process:)
+      end
+
       def payload(data)
         super(Configuration.for(data, self).to_h)
       end
@@ -73,6 +80,18 @@ module ChatNotifier
       end
 
       private
+
+      # Success posts nothing unless an open episode exists for this key:
+      # then a passed status reply closes the loop and the digest flips the
+      # parent to resolved.
+      def resolve_episode(messenger, process:)
+        ref = thread_store.find(messenger.thread_key, process:)
+        return unless ref&.open?
+
+        post_message(text: status_text(messenger), thread_ts: ref.ts, process:,
+          metadata: {event_type: STATUS_EVENT_TYPE, event_payload: messenger.status_report})
+        update_parent(messenger, ref.ts, process:)
+      end
 
       def post_via_api(messenger, process:)
         return post_message(text: messenger.message, process:) unless messenger.failure?

--- a/lib/chat_notifier/chatter/slack.rb
+++ b/lib/chat_notifier/chatter/slack.rb
@@ -9,6 +9,7 @@ module ChatNotifier
 
       API_URL = "https://slack.com/api/chat.postMessage"
       DEFAULT_THREAD_GROUP_SIZE = 10
+      STATUS_EVENT_TYPE = "chat_notifier_status"
 
       class << self
         def handles?(settings)
@@ -88,6 +89,14 @@ module ChatNotifier
         FailureGroups.new(messenger.failures, group_size: thread_group_size).reply_texts.each do |text|
           post_message(text:, thread_ts:, process:)
         end
+
+        post_message(text: status_text(messenger), thread_ts:, process:,
+          metadata: {event_type: STATUS_EVENT_TYPE, event_payload: messenger.status_report})
+      end
+
+      def status_text(messenger)
+        report = messenger.status_report
+        "#{report[:job]}: #{report[:status]}"
       end
 
       def parent_metadata(key)

--- a/lib/chat_notifier/chatter/slack.rb
+++ b/lib/chat_notifier/chatter/slack.rb
@@ -75,7 +75,7 @@ module ChatNotifier
         return post_message(text: messenger.message, process:) unless messenger.failure?
 
         key = messenger.thread_key
-        ref = thread_store.find(key)
+        ref = thread_store.find(key, process:)
         thread_ts = ref&.open? ? ref.ts : nil
 
         unless thread_ts

--- a/lib/chat_notifier/messenger.rb
+++ b/lib/chat_notifier/messenger.rb
@@ -70,6 +70,27 @@ module ChatNotifier
 
     def failure? = !success?
 
+    # Render a parent-message summary from the thread's status reports,
+    # keeping only the latest run's report per job. Deterministic for any
+    # ordering of the same reports so repeated recomputes converge.
+    def digest(reports)
+      latest = latest_run(reports)
+      parts = latest.sort_by { |report| report["job"].to_s }.map do |report|
+        if report["status"] == "passed"
+          "#{report["job"]} ✅"
+        else
+          "#{report["job"]} ❌ #{report["failures"]}"
+        end
+      end
+      prefix = resolved?(reports) ? "✅" : message_prefix
+      "#{prefix} #{identifier} in #{branch} · #{parts.join(" · ")}\n#{environment.test_run_url}"
+    end
+
+    def resolved?(reports)
+      latest = latest_run(reports)
+      !latest.empty? && latest.all? { |report| report["status"] == "passed" }
+    end
+
     def to_h
       {
         text: message
@@ -110,6 +131,18 @@ module ChatNotifier
       def body
         failures.flat_map(&:location).join("\n")
       end
+    end
+
+    private
+
+    def latest_run(reports)
+      grouped = reports.group_by { |report| report["run_id"].to_s }
+      latest_id = grouped.keys.max_by { |id| [id.length, id] }
+      # [length, value] orders numeric strings correctly ("9" < "10") and
+      # sorts nil run_ids ("") as the oldest run.
+      # conversations.replies returns replies oldest-first, so uniq keeps the
+      # earliest status per job per run; jobs post once per run, so it's fine.
+      grouped.fetch(latest_id, []).uniq { |report| report["job"] }
     end
   end
 end

--- a/lib/chat_notifier/messenger.rb
+++ b/lib/chat_notifier/messenger.rb
@@ -56,6 +56,10 @@ module ChatNotifier
       "#{app} #{ruby_version} #{sha}"
     end
 
+    def thread_key
+      "#{app}##{environment.pull_request_ref || branch}"
+    end
+
     def message_prefix = ":thumbsup:"
 
     def success? = true

--- a/lib/chat_notifier/messenger.rb
+++ b/lib/chat_notifier/messenger.rb
@@ -73,8 +73,10 @@ module ChatNotifier
     def failure? = !success?
 
     # Render a parent-message summary from the thread's status reports,
-    # keeping only the latest run's report per job. Deterministic for any
-    # ordering of the same reports so repeated recomputes converge.
+    # keeping only the latest run's report per job. A pure function of the
+    # reports plus state shared across matrix jobs (app, sha, branch,
+    # test_run_url) — never the writer's own ruby version or success state —
+    # so any writer, in any order, converges on identical text.
     def digest(reports)
       latest = latest_run(reports)
       parts = latest.sort_by { |report| report["job"].to_s }.map do |report|
@@ -84,8 +86,8 @@ module ChatNotifier
           "#{report["job"]} ❌ #{report["failures"]}"
         end
       end
-      prefix = resolved?(reports) ? "✅" : message_prefix
-      "#{prefix} #{identifier} in #{branch} · #{parts.join(" · ")}\n#{environment.test_run_url}"
+      prefix = resolved?(reports) ? "✅" : ":boom:"
+      "#{prefix} #{app} #{sha} in #{branch} · #{parts.join(" · ")}\n#{environment.test_run_url}"
     end
 
     def resolved?(reports)

--- a/lib/chat_notifier/messenger.rb
+++ b/lib/chat_notifier/messenger.rb
@@ -62,6 +62,10 @@ module ChatNotifier
 
     def message_prefix = ":thumbsup:"
 
+    def status_report
+      {job: environment.job_identifier, status: "passed", failures: 0, run_id: environment.run_id}
+    end
+
     def success? = true
 
     def failure? = !success?
@@ -82,6 +86,10 @@ module ChatNotifier
       def success? = false
 
       def failure? = !success?
+
+      def status_report
+        super.merge(status: "failed", failures: failures.size)
+      end
 
       def lede
         <<~LEDE.chomp

--- a/lib/chat_notifier/messenger.rb
+++ b/lib/chat_notifier/messenger.rb
@@ -63,7 +63,9 @@ module ChatNotifier
     def message_prefix = ":thumbsup:"
 
     def status_report
-      {job: environment.job_identifier, status: "passed", failures: 0, run_id: environment.run_id}
+      # The payload field stays named run_id (persisted in existing threads)
+      # but carries run_key so re-run attempts group as newer runs.
+      {job: environment.job_identifier, status: "passed", failures: 0, run_id: environment.run_key}
     end
 
     def success? = true

--- a/lib/chat_notifier/test_environment.rb
+++ b/lib/chat_notifier/test_environment.rb
@@ -38,6 +38,10 @@ module ChatNotifier
     def run_id
     end
 
+    # Key used to group status reports by run in the parent digest. Distinct
+    # from run_id (which URLs need bare) so re-runs can sort as newer runs.
+    def run_key = run_id
+
     def pull_request_ref
     end
   end

--- a/lib/chat_notifier/test_environment.rb
+++ b/lib/chat_notifier/test_environment.rb
@@ -27,6 +27,9 @@ module ChatNotifier
 
     def test_run_url
     end
+
+    def pull_request_ref
+    end
   end
 end
 

--- a/lib/chat_notifier/test_environment.rb
+++ b/lib/chat_notifier/test_environment.rb
@@ -28,6 +28,16 @@ module ChatNotifier
     def test_run_url
     end
 
+    def job_identifier
+      settings.fetch("NOTIFY_JOB_NAME") do
+        job = settings.fetch("GITHUB_JOB", "test")
+        "#{job} ruby-#{RUBY_VERSION}"
+      end
+    end
+
+    def run_id
+    end
+
     def pull_request_ref
     end
   end

--- a/lib/chat_notifier/test_environment/github.rb
+++ b/lib/chat_notifier/test_environment/github.rb
@@ -10,6 +10,11 @@ module ChatNotifier
       def run_id
         settings.fetch("NOTIFY_TEST_RUN_ID")
       end
+
+      def pull_request_ref
+        ref = settings.fetch("GITHUB_HEAD_REF", nil)
+        ref unless ref.nil? || ref.empty?
+      end
     end
   end
 end

--- a/lib/chat_notifier/test_environment/github.rb
+++ b/lib/chat_notifier/test_environment/github.rb
@@ -8,7 +8,9 @@ module ChatNotifier
       end
 
       def run_id
-        settings.fetch("NOTIFY_TEST_RUN_ID")
+        settings.fetch("NOTIFY_TEST_RUN_ID") do
+          settings.fetch("GITHUB_RUN_ID", nil)
+        end
       end
 
       def pull_request_ref

--- a/lib/chat_notifier/test_environment/github.rb
+++ b/lib/chat_notifier/test_environment/github.rb
@@ -13,6 +13,17 @@ module ChatNotifier
         end
       end
 
+      # "Re-run failed jobs" reuses GITHUB_RUN_ID (only GITHUB_RUN_ATTEMPT
+      # changes), so the attempt suffix lets a re-run pass supersede the
+      # original failure in the digest instead of being dropped as a
+      # duplicate of the same run.
+      def run_key
+        attempt = settings.fetch("GITHUB_RUN_ATTEMPT", nil)
+        return run_id unless run_id && attempt
+
+        "#{run_id}.#{attempt}"
+      end
+
       def pull_request_ref
         ref = settings.fetch("GITHUB_HEAD_REF", nil)
         ref unless ref.nil? || ref.empty?

--- a/lib/chat_notifier/thread_store.rb
+++ b/lib/chat_notifier/thread_store.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module ChatNotifier
+  # Strategy for persisting the mapping from a branch/PR key to a chat thread.
+  # Implementations provide find(key) => ThreadRef | nil and record(key, ref).
+  class ThreadStore
+    ThreadRef = Data.define(:ts, :status) do
+      def open? = status != "resolved"
+    end
+
+    class Null < self
+      def find(key) = nil
+
+      def record(key, ref) = nil
+    end
+  end
+end

--- a/lib/chat_notifier/thread_store.rb
+++ b/lib/chat_notifier/thread_store.rb
@@ -2,14 +2,16 @@
 
 module ChatNotifier
   # Strategy for persisting the mapping from a branch/PR key to a chat thread.
-  # Implementations provide find(key) => ThreadRef | nil and record(key, ref).
+  # Implementations provide find(key, process: nil) => ThreadRef | nil and
+  # record(key, ref). The optional process is an injectable transport callable
+  # passed through by callers; nil means use the implementation's default.
   class ThreadStore
     ThreadRef = Data.define(:ts, :status) do
       def open? = status != "resolved"
     end
 
     class Null < self
-      def find(key) = nil
+      def find(key, process: nil) = nil
 
       def record(key, ref) = nil
     end

--- a/lib/chat_notifier/thread_store.rb
+++ b/lib/chat_notifier/thread_store.rb
@@ -15,3 +15,5 @@ module ChatNotifier
     end
   end
 end
+
+require_relative "thread_store/slack_metadata"

--- a/lib/chat_notifier/thread_store/slack_metadata.rb
+++ b/lib/chat_notifier/thread_store/slack_metadata.rb
@@ -15,12 +15,8 @@ module ChatNotifier
 
       attr_reader :chatter
 
-      def find(key)
-        response = chatter.api_form_post(HISTORY_URL, {
-          channel: chatter.channel,
-          limit: HISTORY_LIMIT,
-          include_all_metadata: true
-        })
+      def find(key, process: nil)
+        response = fetch_history(process)
         unless response["ok"]
           ChatNotifier.logger.error(
             "ChatNotifier: thread lookup failed: #{response.fetch("error", "unrecognized response")}"
@@ -37,6 +33,18 @@ module ChatNotifier
       def record(key, ref) = nil
 
       private
+
+      # A nil process defers to the chatter's own default transport.
+      def fetch_history(process)
+        params = {
+          channel: chatter.channel,
+          limit: HISTORY_LIMIT,
+          include_all_metadata: true
+        }
+        return chatter.api_form_post(HISTORY_URL, params) unless process
+
+        chatter.api_form_post(HISTORY_URL, params, process:)
+      end
 
       def matching_message(response, key)
         (response["messages"] || []).find do |message|

--- a/lib/chat_notifier/thread_store/slack_metadata.rb
+++ b/lib/chat_notifier/thread_store/slack_metadata.rb
@@ -27,6 +27,10 @@ module ChatNotifier
         return nil unless message
 
         ThreadRef.new(ts: message["ts"], status: message.dig("metadata", "event_payload", "status"))
+      rescue => error
+        # A failed lookup must never abort posting the notification itself.
+        ChatNotifier.logger.error("ChatNotifier: thread lookup failed: #{error.message}")
+        nil
       end
 
       # Posting the parent with metadata is the record; nothing separate to do.

--- a/lib/chat_notifier/thread_store/slack_metadata.rb
+++ b/lib/chat_notifier/thread_store/slack_metadata.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module ChatNotifier
+  class ThreadStore
+    # Uses the Slack channel itself as the store: parents are posted with
+    # message metadata carrying the thread key; find scans recent history.
+    class SlackMetadata < self
+      EVENT_TYPE = "chat_notifier_thread"
+      HISTORY_URL = "https://slack.com/api/conversations.history"
+      HISTORY_LIMIT = 200
+
+      def initialize(chatter:)
+        @chatter = chatter
+      end
+
+      attr_reader :chatter
+
+      def find(key)
+        response = chatter.api_form_post(HISTORY_URL, {
+          channel: chatter.channel,
+          limit: HISTORY_LIMIT,
+          include_all_metadata: true
+        })
+        unless response["ok"]
+          ChatNotifier.logger.error(
+            "ChatNotifier: thread lookup failed: #{response.fetch("error", "unrecognized response")}"
+          )
+          return nil
+        end
+        message = matching_message(response, key)
+        return nil unless message
+
+        ThreadRef.new(ts: message["ts"], status: message.dig("metadata", "event_payload", "status"))
+      end
+
+      # Posting the parent with metadata is the record; nothing separate to do.
+      def record(key, ref) = nil
+
+      private
+
+      def matching_message(response, key)
+        (response["messages"] || []).find do |message|
+          message.dig("metadata", "event_type") == EVENT_TYPE &&
+            message.dig("metadata", "event_payload", "key") == key
+        end
+      end
+    end
+  end
+end

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -38,10 +38,25 @@ describe ChatNotifier::App do
       expect(app.branch).must_equal("main")
     end
 
-    it "falls back to the current git branch when settings provide nothing" do
-      app = ChatNotifier::App.new(name: "MyApp", settings: {})
-      expect(app.branch).must_be_instance_of(String)
-      refute app.branch.empty?, "expected the git branch fallback to produce a value"
+    it "falls back to git via the runner when settings provide nothing" do
+      commands = []
+      runner = ->(command) {
+        commands << command
+        "feature-x\n"
+      }
+      app = ChatNotifier::App.new(name: "MyApp", settings: {}, runner:)
+      expect(app.branch).must_equal("feature-x")
+      expect(commands).must_equal(["git branch --show-current"])
+    end
+
+    it "returns nil when git has no answer (e.g. detached HEAD in CI)" do
+      app = ChatNotifier::App.new(name: "MyApp", settings: {}, runner: ->(_) { "" })
+      assert_nil app.branch
+    end
+
+    it "returns nil when the runner raises" do
+      app = ChatNotifier::App.new(name: "MyApp", settings: {}, runner: ->(_) { raise Errno::ENOENT })
+      assert_nil app.branch
     end
   end
 
@@ -62,10 +77,15 @@ describe ChatNotifier::App do
       expect(app.sha).must_equal("def5678")
     end
 
-    it "falls back to the current git sha when settings provide nothing" do
-      app = ChatNotifier::App.new(name: "MyApp", settings: {})
-      expect(app.sha).must_be_instance_of(String)
-      refute app.sha.empty?, "expected the git sha fallback to produce a value"
+    it "falls back to git via the runner when settings provide nothing" do
+      commands = []
+      runner = ->(command) {
+        commands << command
+        "abc1234\n"
+      }
+      app = ChatNotifier::App.new(name: "MyApp", settings: {}, runner:)
+      expect(app.sha).must_equal("abc1234")
+      expect(commands).must_equal(["git rev-parse --short HEAD"])
     end
   end
 

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "chat_notifier/app"
+
+describe ChatNotifier::App do
+  describe "#to_s" do
+    it "returns the name" do
+      app = ChatNotifier::App.new(name: "MyApp", settings: {})
+      expect(app.to_s).must_equal("MyApp")
+    end
+  end
+
+  describe "#branch" do
+    it "prefers NOTIFY_BRANCH over CI-provided refs" do
+      app = ChatNotifier::App.new(name: "MyApp", settings: {
+        "NOTIFY_BRANCH" => "custom-branch",
+        "GITHUB_HEAD_REF" => "pr-head",
+        "GITHUB_REF_NAME" => "ref-name"
+      })
+      expect(app.branch).must_equal("custom-branch")
+    end
+
+    it "falls back to GITHUB_HEAD_REF, skipping empty settings" do
+      app = ChatNotifier::App.new(name: "MyApp", settings: {
+        "NOTIFY_BRANCH" => "",
+        "GITHUB_HEAD_REF" => "pr-head",
+        "GITHUB_REF_NAME" => "ref-name"
+      })
+      expect(app.branch).must_equal("pr-head")
+    end
+
+    it "falls back to GITHUB_REF_NAME when GITHUB_HEAD_REF is empty" do
+      app = ChatNotifier::App.new(name: "MyApp", settings: {
+        "GITHUB_HEAD_REF" => "",
+        "GITHUB_REF_NAME" => "main"
+      })
+      expect(app.branch).must_equal("main")
+    end
+
+    it "falls back to the current git branch when settings provide nothing" do
+      app = ChatNotifier::App.new(name: "MyApp", settings: {})
+      expect(app.branch).must_be_instance_of(String)
+      refute app.branch.empty?, "expected the git branch fallback to produce a value"
+    end
+  end
+
+  describe "#sha" do
+    it "prefers NOTIFY_SHA over GITHUB_SHA" do
+      app = ChatNotifier::App.new(name: "MyApp", settings: {
+        "NOTIFY_SHA" => "abc1234",
+        "GITHUB_SHA" => "def5678"
+      })
+      expect(app.sha).must_equal("abc1234")
+    end
+
+    it "falls back to GITHUB_SHA, skipping empty settings" do
+      app = ChatNotifier::App.new(name: "MyApp", settings: {
+        "NOTIFY_SHA" => "",
+        "GITHUB_SHA" => "def5678"
+      })
+      expect(app.sha).must_equal("def5678")
+    end
+
+    it "falls back to the current git sha when settings provide nothing" do
+      app = ChatNotifier::App.new(name: "MyApp", settings: {})
+      expect(app.sha).must_be_instance_of(String)
+      refute app.sha.empty?, "expected the git sha fallback to produce a value"
+    end
+  end
+
+  describe "used by a Messenger built through the real factories" do
+    # Regression test: passing a bare String as app: made lede/message/
+    # thread_key raise NoMethodError (undefined method 'branch' for String),
+    # silently dropping every production notification.
+    let(:settings) do
+      {
+        "NOTIFY_APP_NAME" => "MyApp",
+        "NOTIFY_CURRENT_REPOSITORY_URL" => "https://github.com/test/repo",
+        "NOTIFY_TEST_RUN_ID" => "1",
+        "NOTIFY_BRANCH" => "feature-branch",
+        "NOTIFY_SHA" => "abc1234"
+      }
+    end
+
+    let(:messenger) do
+      ChatNotifier::Messenger.for(
+        ChatNotifier::DebugSummary.new(failed_examples: []),
+        repository: ChatNotifier::Repository.for(settings),
+        environment: ChatNotifier::TestEnvironment.for(settings),
+        app: ChatNotifier::App.new(name: ChatNotifier.app(env: settings), settings: settings)
+      )
+    end
+
+    it "resolves thread_key with the branch" do
+      expect(messenger.thread_key).must_equal("MyApp#feature-branch")
+    end
+
+    it "resolves lede with the sha and branch" do
+      expect(messenger.lede).must_include("abc1234")
+      expect(messenger.lede).must_include("feature-branch")
+    end
+
+    it "resolves message with the sha and branch" do
+      expect(messenger.message).must_include("abc1234")
+      expect(messenger.message).must_include("feature-branch")
+    end
+  end
+end

--- a/test/chat_notifier_test.rb
+++ b/test/chat_notifier_test.rb
@@ -139,6 +139,61 @@ module ChatNotifier
       end
     end
 
+    def test_call_injects_thread_store_into_chatters
+      original_app_name = ENV["NOTIFY_APP_NAME"]
+      ENV["NOTIFY_APP_NAME"] = "TestApp"
+
+      injected_store = Object.new
+      test_box_class = Class.new do
+        attr_accessor :thread_store
+
+        def conditional_post(messenger)
+          # Test that conditional_post was called
+        end
+      end
+      test_box = test_box_class.new
+
+      factory = ->(value) {
+        f = Class.new
+        f.define_singleton_method(:for) { |*, **| value }
+        f
+      }
+      chatter_factory_for = ->(box) {
+        f = Class.new
+        f.define_singleton_method(:handling) { |env, repository:, environment:| [box] }
+        f
+      }
+
+      ChatNotifier.call(
+        summary: @summary,
+        repository: factory.call(Object.new),
+        environment: factory.call(Object.new),
+        chatter: chatter_factory_for.call(test_box),
+        messenger: factory.call(Object.new),
+        thread_store: injected_store
+      )
+
+      assert_same injected_store, test_box.thread_store
+
+      # Without thread_store: the chatter's own default must be left alone.
+      untouched_box = test_box_class.new
+      ChatNotifier.call(
+        summary: @summary,
+        repository: factory.call(Object.new),
+        environment: factory.call(Object.new),
+        chatter: chatter_factory_for.call(untouched_box),
+        messenger: factory.call(Object.new)
+      )
+
+      assert_nil untouched_box.thread_store
+    ensure
+      if original_app_name.nil?
+        ENV.delete("NOTIFY_APP_NAME")
+      else
+        ENV["NOTIFY_APP_NAME"] = original_app_name
+      end
+    end
+
     def test_call_logs_errors_without_leaking_the_webhook_url
       original_app_name = ENV["NOTIFY_APP_NAME"]
       ENV["NOTIFY_APP_NAME"] = "TestApp"

--- a/test/chat_notifier_test.rb
+++ b/test/chat_notifier_test.rb
@@ -5,7 +5,7 @@ module ChatNotifier
   class Test < Minitest::Test
     def setup
       # Setup any necessary test data or mocks here
-      @env = {} # Replace with actual environment data if needed
+      @env = {"NOTIFY_APP_NAME" => "TestApp"}
       @summary = "Test summary"
     end
 

--- a/test/chatter/slack_test.rb
+++ b/test/chatter/slack_test.rb
@@ -328,9 +328,10 @@ describe ChatNotifier::Chatter::Slack do
         FakeResponse.new(%({"ok":false,"error":"channel_not_found"}))
       end
 
-      communicator.post(messenger, process:)
+      logged = capture_logs { communicator.post(messenger, process:) }
 
       expect(calls.size).must_equal(1)
+      expect(logged).must_match(/channel_not_found/)
     end
 
     it "does not post replies when the parent response has no ts" do

--- a/test/chatter/slack_test.rb
+++ b/test/chatter/slack_test.rb
@@ -10,6 +10,16 @@ RateLimitedResponse = Struct.new(:body, :code, :headers) do
 end
 MessengerDouble = Struct.new(:success?, :failure?, :lede, :message, :failures, :thread_key)
 FailureLoc = Struct.new(:location)
+StoreDouble = Struct.new(:ref) do
+  def find(key, process: nil)
+    finds << [key, process]
+    ref
+  end
+
+  def finds
+    @finds ||= []
+  end
+end
 
 describe ChatNotifier::Chatter::Slack do
   let(:settings) do
@@ -122,6 +132,9 @@ describe ChatNotifier::Chatter::Slack do
     end
 
     before do
+      # Pin a null store so these examples exercise posting behavior alone.
+      # With the default SlackMetadata store the first recorded call would be
+      # the conversations.history lookup rather than the parent message.
       communicator.thread_store = ChatNotifier::ThreadStore::Null.new
     end
 
@@ -168,21 +181,28 @@ describe ChatNotifier::Chatter::Slack do
     end
 
     it "threads into an existing open thread instead of posting a parent" do
-      store = mimic(find: [ChatNotifier::ThreadStore::ThreadRef.new(ts: "7.7", status: "failing"), "app#main"])
+      store = StoreDouble.new(ChatNotifier::ThreadStore::ThreadRef.new(ts: "7.7", status: "failing"))
       communicator.thread_store = store
-      calls = record_calls { |process| communicator.post(messenger, process:) }
+      seen_process = nil
+      calls = record_calls do |process|
+        seen_process = process
+        communicator.post(messenger, process:)
+      end
 
       refute calls.any? { |c| !c[:body].key?("thread_ts") }, "no new parent expected"
       expect(calls.first[:body]["thread_ts"]).must_equal("7.7")
-      store.verify
+      expect(store.finds).must_equal([["app#main", seen_process]])
     end
 
     it "starts a new thread when the existing thread is resolved" do
-      store = mimic(find: [ChatNotifier::ThreadStore::ThreadRef.new(ts: "7.7", status: "resolved"), "app#main"])
+      store = StoreDouble.new(ChatNotifier::ThreadStore::ThreadRef.new(ts: "7.7", status: "resolved"))
       communicator.thread_store = store
       calls = record_calls { |process| communicator.post(messenger, process:) }
 
       refute calls.first[:body].key?("thread_ts"), "resolved thread must not be reused"
+      metadata = calls.first[:body]["metadata"]
+      expect(metadata["event_payload"]["key"]).must_equal("app#main")
+      expect(metadata["event_payload"]["status"]).must_equal("failing")
     end
 
     it "prefers the bot token over a configured webhook" do

--- a/test/chatter/slack_test.rb
+++ b/test/chatter/slack_test.rb
@@ -8,7 +8,7 @@ FakeResponse = Struct.new(:body)
 RateLimitedResponse = Struct.new(:body, :code, :headers) do
   def [](key) = headers[key]
 end
-MessengerDouble = Struct.new(:success?, :failure?, :lede, :message, :failures)
+MessengerDouble = Struct.new(:success?, :failure?, :lede, :message, :failures, :thread_key)
 FailureLoc = Struct.new(:location)
 
 describe ChatNotifier::Chatter::Slack do
@@ -83,6 +83,20 @@ describe ChatNotifier::Chatter::Slack do
     end
   end
 
+  describe "#thread_store" do
+    it "defaults to the SlackMetadata store when a bot token is configured" do
+      chatter = ChatNotifier::Chatter::Slack.new(
+        settings: {"NOTIFY_SLACK_BOT_TOKEN" => "xoxb-123"}, repository: nil, environment: nil
+      )
+      expect(chatter.thread_store).must_be_instance_of(ChatNotifier::ThreadStore::SlackMetadata)
+    end
+
+    it "defaults to the null store when only a webhook is configured" do
+      chatter = ChatNotifier::Chatter::Slack.new(settings:, repository: nil, environment: nil)
+      expect(chatter.thread_store).must_be_instance_of(ChatNotifier::ThreadStore::Null)
+    end
+  end
+
   describe "#post with a bot token configured" do
     let(:settings) do
       {
@@ -102,8 +116,13 @@ describe ChatNotifier::Chatter::Slack do
         failures: [
           FailureLoc.new("test/a_test.rb:1"),
           FailureLoc.new("test/b_test.rb:2")
-        ]
+        ],
+        thread_key: "app#main"
       )
+    end
+
+    before do
+      communicator.thread_store = ChatNotifier::ThreadStore::Null.new
     end
 
     def record_calls
@@ -137,6 +156,33 @@ describe ChatNotifier::Chatter::Slack do
       end
       expect(replies[0][:body]["text"]).must_match(%r{test/a_test\.rb})
       expect(replies[1][:body]["text"]).must_match(%r{test/b_test\.rb})
+    end
+
+    it "posts parents with thread metadata carrying the key" do
+      calls = record_calls { |process| communicator.post(messenger, process:) }
+
+      metadata = calls.first[:body]["metadata"]
+      expect(metadata["event_type"]).must_equal("chat_notifier_thread")
+      expect(metadata["event_payload"]["key"]).must_equal("app#main")
+      expect(metadata["event_payload"]["status"]).must_equal("failing")
+    end
+
+    it "threads into an existing open thread instead of posting a parent" do
+      store = mimic(find: [ChatNotifier::ThreadStore::ThreadRef.new(ts: "7.7", status: "failing"), "app#main"])
+      communicator.thread_store = store
+      calls = record_calls { |process| communicator.post(messenger, process:) }
+
+      refute calls.any? { |c| !c[:body].key?("thread_ts") }, "no new parent expected"
+      expect(calls.first[:body]["thread_ts"]).must_equal("7.7")
+      store.verify
+    end
+
+    it "starts a new thread when the existing thread is resolved" do
+      store = mimic(find: [ChatNotifier::ThreadStore::ThreadRef.new(ts: "7.7", status: "resolved"), "app#main"])
+      communicator.thread_store = store
+      calls = record_calls { |process| communicator.post(messenger, process:) }
+
+      refute calls.first[:body].key?("thread_ts"), "resolved thread must not be reused"
     end
 
     it "prefers the bot token over a configured webhook" do
@@ -244,7 +290,8 @@ describe ChatNotifier::Chatter::Slack do
           failure?: false,
           lede: "ignored",
           message: ":thumbsup: all good",
-          failures: []
+          failures: [],
+          thread_key: "app#main"
         )
       end
 

--- a/test/chatter/slack_test.rb
+++ b/test/chatter/slack_test.rb
@@ -157,6 +157,39 @@ describe ChatNotifier::Chatter::Slack do
       chatter = ChatNotifier::Chatter::Slack.new(settings:, repository: nil, environment: nil)
       expect(chatter.thread_store).must_be_instance_of(ChatNotifier::ThreadStore::Null)
     end
+
+    it "uses the Null store when NOTIFY_THREAD_STORE is none" do
+      chatter = ChatNotifier::Chatter::Slack.new(
+        settings: {"NOTIFY_SLACK_BOT_TOKEN" => "xoxb-123", "NOTIFY_THREAD_STORE" => "none"},
+        repository: nil, environment: nil
+      )
+      expect(chatter.thread_store).must_be_instance_of(ChatNotifier::ThreadStore::Null)
+    end
+  end
+
+  describe "#conditional_post with only a webhook configured" do
+    let(:communicator) { ChatNotifier::Chatter::Slack.new(settings:, repository: nil, environment: nil) }
+
+    it "posts nothing for a non-verbose success" do
+      messenger = MessengerDouble.new(
+        success?: true,
+        failure?: false,
+        lede: "ignored",
+        message: ":thumbsup: all good",
+        failures: [],
+        thread_key: "app#main",
+        status_report: {job: "test ruby-3.4", status: "passed", failures: 0, run_id: "43"}
+      )
+      calls = []
+      process = lambda do |uri, body, headers = nil|
+        calls << uri.to_s
+        FakeResponse.new("ok")
+      end
+
+      communicator.conditional_post(messenger, process:)
+
+      expect(calls).must_be_empty
+    end
   end
 
   describe "#post with a bot token configured" do
@@ -525,17 +558,21 @@ describe ChatNotifier::Chatter::Slack do
         end
 
         it "posts nothing on success when no open episode exists" do
-          communicator.thread_store = StoreDouble.new(nil)
+          store = StoreDouble.new(nil)
+          communicator.thread_store = store
           calls = record_calls { |process| communicator.conditional_post(messenger, process:) }
 
           expect(calls).must_be_empty
+          expect(store.finds.size).must_equal(1)
         end
 
         it "posts nothing on success when the episode is already resolved" do
-          communicator.thread_store = StoreDouble.new(ChatNotifier::ThreadStore::ThreadRef.new(ts: "7.7", status: "resolved"))
+          store = StoreDouble.new(ChatNotifier::ThreadStore::ThreadRef.new(ts: "7.7", status: "resolved"))
+          communicator.thread_store = store
           calls = record_calls { |process| communicator.conditional_post(messenger, process:) }
 
           expect(calls).must_be_empty
+          expect(store.finds.size).must_equal(1)
         end
 
         it "recomputes the parent to resolved after the passed status reply" do

--- a/test/chatter/slack_test.rb
+++ b/test/chatter/slack_test.rb
@@ -213,6 +213,30 @@ describe ChatNotifier::Chatter::Slack do
       expect(bodies[1]["text"]).must_equal(bodies[2]["text"])
     end
 
+    describe "#api_form_post" do
+      it "form-encodes params with the bearer token and parses JSON" do
+        captured = {}
+        process = lambda do |uri, body, headers = nil|
+          captured.merge!(uri: uri.to_s, body:, headers:)
+          FakeResponse.new(%({"ok":true,"messages":[]}))
+        end
+
+        result = communicator.api_form_post("https://slack.com/api/conversations.history",
+          {channel: "#test", limit: 200}, process:)
+
+        expect(captured[:uri]).must_equal("https://slack.com/api/conversations.history")
+        expect(captured[:body]).must_equal("channel=%23test&limit=200")
+        expect(captured[:headers]["Content-Type"]).must_equal("application/x-www-form-urlencoded")
+        expect(captured[:headers]["Authorization"]).must_equal("Bearer xoxb-test-token")
+        expect(result).must_equal({"ok" => true, "messages" => []})
+      end
+
+      it "returns an empty hash on unparseable responses" do
+        process = ->(uri, body, headers = nil) { FakeResponse.new("not json") }
+        expect(communicator.api_form_post("https://slack.com/api/x", {}, process:)).must_equal({})
+      end
+    end
+
     describe "when the run succeeds" do
       let(:messenger) do
         MessengerDouble.new(

--- a/test/chatter/slack_test.rb
+++ b/test/chatter/slack_test.rb
@@ -344,18 +344,20 @@ describe ChatNotifier::Chatter::Slack do
     describe "recomputing the parent digest after the status reply" do
       let(:messenger) { DigestMessengerDouble.new }
 
-      let(:replies_body) do
-        JSON.generate({
-          ok: true,
-          messages: [
-            {ts: "111.222", text: "parent"},
-            {ts: "111.300", metadata: {event_type: "chat_notifier_status",
-                                       event_payload: {job: "test ruby-3.2", status: "failed", failures: 3, run_id: "42"}}},
-            {ts: "111.400", metadata: {event_type: "chat_notifier_status",
-                                       event_payload: {job: "test ruby-3.3", status: "passed", failures: 0, run_id: "42"}}}
-          ]
-        })
+      let(:status_messages) do
+        [
+          {ts: "111.300", metadata: {event_type: "chat_notifier_status",
+                                     event_payload: {job: "test ruby-3.2", status: "failed", failures: 3, run_id: "42"}}},
+          {ts: "111.400", metadata: {event_type: "chat_notifier_status",
+                                     event_payload: {job: "test ruby-3.3", status: "passed", failures: 0, run_id: "42"}}}
+        ]
       end
+
+      let(:replies_payload) do
+        {ok: true, messages: [{ts: "111.222", text: "parent"}] + status_messages}
+      end
+
+      let(:replies_body) { JSON.generate(replies_payload) }
 
       def run_with_scripted_replies(messenger)
         responses = [
@@ -381,6 +383,7 @@ describe ChatNotifier::Chatter::Slack do
         expect(fetch[:uri]).must_equal("https://slack.com/api/conversations.replies")
         expect(fetch[:body]).must_match(/ts=111\.222/)
         expect(fetch[:body]).must_match(/include_all_metadata/)
+        expect(fetch[:body]).must_match(/limit=1000/)
       end
 
       it "updates the parent with the digest of the status reports" do
@@ -413,6 +416,31 @@ describe ChatNotifier::Chatter::Slack do
         body = JSON.parse(calls.last[:body])
         expect(calls.last[:uri]).must_equal("https://slack.com/api/chat.update")
         expect(body["metadata"]["event_payload"]["status"]).must_equal("resolved")
+      end
+
+      describe "when the thread has more replies than one fetch returns" do
+        let(:replies_payload) do
+          {ok: true, has_more: true, messages: [{ts: "111.222", text: "parent"}] + status_messages}
+        end
+
+        it "warns that the digest may be stale but still updates the parent" do
+          calls = nil
+          logged = capture_logs { calls = run_with_scripted_replies(messenger) }
+
+          expect(logged).must_match(/truncated/)
+          expect(calls.last[:uri]).must_equal("https://slack.com/api/chat.update")
+        end
+      end
+
+      describe "when the replies fetch fails" do
+        let(:replies_body) { %({"ok":false,"error":"missing_scope"}) }
+
+        it "does not update the parent" do
+          calls = run_with_scripted_replies(messenger)
+
+          refute calls.any? { |call| call[:uri] == "https://slack.com/api/chat.update" }, "no update expected"
+          assert_nil messenger.digest_reports
+        end
       end
     end
 

--- a/test/chatter/slack_test.rb
+++ b/test/chatter/slack_test.rb
@@ -8,7 +8,7 @@ FakeResponse = Struct.new(:body)
 RateLimitedResponse = Struct.new(:body, :code, :headers) do
   def [](key) = headers[key]
 end
-MessengerDouble = Struct.new(:success?, :failure?, :lede, :message, :failures, :thread_key)
+MessengerDouble = Struct.new(:success?, :failure?, :lede, :message, :failures, :thread_key, :status_report)
 FailureLoc = Struct.new(:location)
 StoreDouble = Struct.new(:ref) do
   def find(key, process: nil)
@@ -127,7 +127,8 @@ describe ChatNotifier::Chatter::Slack do
           FailureLoc.new("test/a_test.rb:1"),
           FailureLoc.new("test/b_test.rb:2")
         ],
-        thread_key: "app#main"
+        thread_key: "app#main",
+        status_report: {job: "test ruby-3.4", status: "failed", failures: 2, run_id: "42"}
       )
     end
 
@@ -162,13 +163,23 @@ describe ChatNotifier::Chatter::Slack do
     it "posts each failure group as a threaded reply using the parent ts" do
       calls = record_calls { |process| communicator.post(messenger, process:) }
 
-      replies = calls.drop(1)
+      replies = calls[1..-2] # between the parent and the trailing status reply
       expect(replies.size).must_equal(2)
       replies.each do |reply|
         expect(reply[:body]["thread_ts"]).must_equal("111.222")
       end
       expect(replies[0][:body]["text"]).must_match(%r{test/a_test\.rb})
       expect(replies[1][:body]["text"]).must_match(%r{test/b_test\.rb})
+    end
+
+    it "posts a status reply with metadata after the failure replies" do
+      calls = record_calls { |process| communicator.post(messenger, process:) }
+
+      status = calls.last[:body]
+      expect(status["thread_ts"]).must_equal("111.222")
+      expect(status["metadata"]["event_type"]).must_equal("chat_notifier_status")
+      expect(status["metadata"]["event_payload"]["job"]).must_equal("test ruby-3.4")
+      expect(status["metadata"]["event_payload"]["status"]).must_equal("failed")
     end
 
     it "posts parents with thread metadata carrying the key" do
@@ -274,8 +285,8 @@ describe ChatNotifier::Chatter::Slack do
       communicator.post(messenger, process:)
 
       expect(slept).must_equal([7])
-      # parent + first reply + its retry + second reply
-      expect(bodies.size).must_equal(4)
+      # parent + first reply + its retry + second reply + status reply
+      expect(bodies.size).must_equal(5)
       expect(bodies[1]["text"]).must_equal(bodies[2]["text"])
     end
 

--- a/test/chatter/slack_test.rb
+++ b/test/chatter/slack_test.rb
@@ -55,6 +55,24 @@ class DigestMessengerDouble
   end
 end
 
+# A passing run: success messengers still expose digest/resolved? (inherited
+# from the base Messenger in production) so the parent can flip to resolved.
+class SuccessDigestMessengerDouble < DigestMessengerDouble
+  def initialize
+    super(resolved: true)
+  end
+
+  def success? = true
+
+  def failure? = false
+
+  def message = ":thumbsup: all good"
+
+  def failures = []
+
+  def status_report = {job: "test ruby-3.4", status: "passed", failures: 0, run_id: "43"}
+end
+
 describe ChatNotifier::Chatter::Slack do
   let(:settings) do
     {
@@ -476,7 +494,8 @@ describe ChatNotifier::Chatter::Slack do
           lede: "ignored",
           message: ":thumbsup: all good",
           failures: [],
-          thread_key: "app#main"
+          thread_key: "app#main",
+          status_report: {job: "test ruby-3.4", status: "passed", failures: 0, run_id: "43"}
         )
       end
 
@@ -486,6 +505,88 @@ describe ChatNotifier::Chatter::Slack do
         expect(calls.size).must_equal(1)
         expect(calls.first[:body]["text"]).must_equal(":thumbsup: all good")
         refute calls.first[:body].key?("thread_ts")
+      end
+
+      describe "#conditional_post" do
+        it "posts resolution into an open episode" do
+          store = StoreDouble.new(ChatNotifier::ThreadStore::ThreadRef.new(ts: "7.7", status: "failing"))
+          communicator.thread_store = store
+          seen_process = nil
+          calls = record_calls do |process|
+            seen_process = process
+            communicator.conditional_post(messenger, process:)
+          end
+
+          status = post_message_calls(calls).first
+          expect(status[:body]["thread_ts"]).must_equal("7.7")
+          expect(status[:body]["metadata"]["event_type"]).must_equal("chat_notifier_status")
+          expect(status[:body]["metadata"]["event_payload"]["status"]).must_equal("passed")
+          expect(store.finds).must_equal([["app#main", seen_process]])
+        end
+
+        it "posts nothing on success when no open episode exists" do
+          communicator.thread_store = StoreDouble.new(nil)
+          calls = record_calls { |process| communicator.conditional_post(messenger, process:) }
+
+          expect(calls).must_be_empty
+        end
+
+        it "posts nothing on success when the episode is already resolved" do
+          communicator.thread_store = StoreDouble.new(ChatNotifier::ThreadStore::ThreadRef.new(ts: "7.7", status: "resolved"))
+          calls = record_calls { |process| communicator.conditional_post(messenger, process:) }
+
+          expect(calls).must_be_empty
+        end
+
+        it "recomputes the parent to resolved after the passed status reply" do
+          messenger = SuccessDigestMessengerDouble.new
+          communicator.thread_store = StoreDouble.new(ChatNotifier::ThreadStore::ThreadRef.new(ts: "7.7", status: "failing"))
+          replies_body = JSON.generate(ok: true, messages: [
+            {ts: "7.7", text: "parent"},
+            {ts: "7.8", metadata: {event_type: "chat_notifier_status",
+                                   event_payload: {job: "test ruby-3.4", status: "passed", failures: 0, run_id: "43"}}}
+          ])
+          responses = [
+            FakeResponse.new(%({"ok":true,"ts":"7.8"})),
+            FakeResponse.new(replies_body),
+            FakeResponse.new(%({"ok":true}))
+          ]
+          calls = []
+          process = lambda do |uri, body, headers = nil|
+            calls << {uri: uri.to_s, body:, headers:}
+            responses.shift || FakeResponse.new(%({"ok":true}))
+          end
+
+          communicator.conditional_post(messenger, process:)
+
+          expect(calls.map { |call| call[:uri] }).must_equal([
+            "https://slack.com/api/chat.postMessage",
+            "https://slack.com/api/conversations.replies",
+            "https://slack.com/api/chat.update"
+          ])
+          body = JSON.parse(calls.last[:body])
+          expect(body["ts"]).must_equal("7.7")
+          expect(body["text"]).must_equal("DIGEST TEXT")
+          expect(body["metadata"]["event_payload"]["status"]).must_equal("resolved")
+        end
+
+        describe "when verbose" do
+          let(:settings) do
+            {
+              "NOTIFY_SLACK_BOT_TOKEN" => "xoxb-test-token",
+              "NOTIFY_SLACK_NOTIFY_CHANNEL" => "#test",
+              "NOTIFIER_VERBOSE" => "true"
+            }
+          end
+
+          it "still posts the plain success message" do
+            calls = record_calls { |process| communicator.conditional_post(messenger, process:) }
+
+            expect(calls.size).must_equal(1)
+            expect(calls.first[:body]["text"]).must_equal(":thumbsup: all good")
+            refute calls.first[:body].key?("thread_ts")
+          end
+        end
       end
     end
   end

--- a/test/chatter/slack_test.rb
+++ b/test/chatter/slack_test.rb
@@ -21,6 +21,40 @@ StoreDouble = Struct.new(:ref) do
   end
 end
 
+# MessengerDouble's Struct members are static values, but digest/resolved?
+# take the reports argument — so this double records what it receives.
+class DigestMessengerDouble
+  def initialize(resolved: false)
+    @resolved = resolved
+  end
+
+  attr_reader :digest_reports, :resolved_reports
+
+  def success? = false
+
+  def failure? = true
+
+  def lede = ":boom: failed in branch main"
+
+  def message = "ignored"
+
+  def failures = [FailureLoc.new("test/a_test.rb:1")]
+
+  def thread_key = "app#main"
+
+  def status_report = {job: "test ruby-3.4", status: "failed", failures: 1, run_id: "42"}
+
+  def digest(reports)
+    @digest_reports = reports
+    "DIGEST TEXT"
+  end
+
+  def resolved?(reports)
+    @resolved_reports = reports
+    @resolved
+  end
+end
+
 describe ChatNotifier::Chatter::Slack do
   let(:settings) do
     {
@@ -139,14 +173,26 @@ describe ChatNotifier::Chatter::Slack do
       communicator.thread_store = ChatNotifier::ThreadStore::Null.new
     end
 
+    # Form-encoded bodies (conversations.replies) are recorded as raw strings.
     def record_calls
       calls = []
       process = lambda do |uri, body, headers = nil|
-        calls << {uri: uri.to_s, body: JSON.parse(body), headers: headers}
+        parsed = begin
+          JSON.parse(body)
+        rescue JSON::ParserError
+          body
+        end
+        calls << {uri: uri.to_s, body: parsed, headers: headers}
         FakeResponse.new(%({"ok":true,"ts":"111.222"}))
       end
       yield process
       calls
+    end
+
+    # chat.postMessage calls only — post_via_api now also fetches
+    # conversations.replies after the status reply.
+    def post_message_calls(calls)
+      calls.select { |call| call[:uri] == "https://slack.com/api/chat.postMessage" }
     end
 
     it "posts the parent message to the Web API with the bearer token" do
@@ -163,7 +209,7 @@ describe ChatNotifier::Chatter::Slack do
     it "posts each failure group as a threaded reply using the parent ts" do
       calls = record_calls { |process| communicator.post(messenger, process:) }
 
-      replies = calls[1..-2] # between the parent and the trailing status reply
+      replies = post_message_calls(calls)[1..-2] # between the parent and the trailing status reply
       expect(replies.size).must_equal(2)
       replies.each do |reply|
         expect(reply[:body]["thread_ts"]).must_equal("111.222")
@@ -175,7 +221,7 @@ describe ChatNotifier::Chatter::Slack do
     it "posts a status reply with metadata after the failure replies" do
       calls = record_calls { |process| communicator.post(messenger, process:) }
 
-      status = calls.last[:body]
+      status = post_message_calls(calls).last[:body]
       expect(status["thread_ts"]).must_equal("111.222")
       expect(status["metadata"]["event_type"]).must_equal("chat_notifier_status")
       expect(status["metadata"]["event_payload"]["job"]).must_equal("test ruby-3.4")
@@ -200,8 +246,9 @@ describe ChatNotifier::Chatter::Slack do
         communicator.post(messenger, process:)
       end
 
-      refute calls.any? { |c| !c[:body].key?("thread_ts") }, "no new parent expected"
-      expect(calls.first[:body]["thread_ts"]).must_equal("7.7")
+      posts = post_message_calls(calls)
+      refute posts.any? { |c| !c[:body].key?("thread_ts") }, "no new parent expected"
+      expect(posts.first[:body]["thread_ts"]).must_equal("7.7")
       expect(store.finds).must_equal([["app#main", seen_process]])
     end
 
@@ -276,7 +323,11 @@ describe ChatNotifier::Chatter::Slack do
       ]
       bodies = []
       process = lambda do |uri, body, headers = nil|
-        bodies << JSON.parse(body)
+        bodies << begin
+          JSON.parse(body)
+        rescue JSON::ParserError
+          body # form-encoded conversations.replies fetch
+        end
         responses.shift || FakeResponse.new(%({"ok":true,"ts":"111.222"}))
       end
       slept = []
@@ -285,9 +336,84 @@ describe ChatNotifier::Chatter::Slack do
       communicator.post(messenger, process:)
 
       expect(slept).must_equal([7])
-      # parent + first reply + its retry + second reply + status reply
-      expect(bodies.size).must_equal(5)
+      # parent + first reply + its retry + second reply + status reply + replies fetch
+      expect(bodies.size).must_equal(6)
       expect(bodies[1]["text"]).must_equal(bodies[2]["text"])
+    end
+
+    describe "recomputing the parent digest after the status reply" do
+      let(:messenger) { DigestMessengerDouble.new }
+
+      let(:replies_body) do
+        JSON.generate({
+          ok: true,
+          messages: [
+            {ts: "111.222", text: "parent"},
+            {ts: "111.300", metadata: {event_type: "chat_notifier_status",
+                                       event_payload: {job: "test ruby-3.2", status: "failed", failures: 3, run_id: "42"}}},
+            {ts: "111.400", metadata: {event_type: "chat_notifier_status",
+                                       event_payload: {job: "test ruby-3.3", status: "passed", failures: 0, run_id: "42"}}}
+          ]
+        })
+      end
+
+      def run_with_scripted_replies(messenger)
+        responses = [
+          FakeResponse.new(%({"ok":true,"ts":"111.222"})),
+          FakeResponse.new(%({"ok":true,"ts":"111.300"})),
+          FakeResponse.new(%({"ok":true,"ts":"111.400"})),
+          FakeResponse.new(replies_body),
+          FakeResponse.new(%({"ok":true}))
+        ]
+        calls = []
+        process = lambda do |uri, body, headers = nil|
+          calls << {uri: uri.to_s, body:, headers:}
+          responses.shift || FakeResponse.new(%({"ok":true}))
+        end
+        communicator.post(messenger, process:)
+        calls
+      end
+
+      it "fetches the thread's replies with metadata after posting the status reply" do
+        calls = run_with_scripted_replies(messenger)
+
+        fetch = calls[3]
+        expect(fetch[:uri]).must_equal("https://slack.com/api/conversations.replies")
+        expect(fetch[:body]).must_match(/ts=111\.222/)
+        expect(fetch[:body]).must_match(/include_all_metadata/)
+      end
+
+      it "updates the parent with the digest of the status reports" do
+        calls = run_with_scripted_replies(messenger)
+
+        update = calls.last
+        expect(update[:uri]).must_equal("https://slack.com/api/chat.update")
+        body = JSON.parse(update[:body])
+        expect(body["channel"]).must_equal("#test")
+        expect(body["ts"]).must_equal("111.222")
+        expect(body["text"]).must_equal("DIGEST TEXT")
+        expect(body["metadata"]["event_type"]).must_equal("chat_notifier_thread")
+        expect(body["metadata"]["event_payload"]["key"]).must_equal("app#main")
+        expect(body["metadata"]["event_payload"]["status"]).must_equal("failing")
+      end
+
+      it "passes the parsed status payloads to the messenger digest" do
+        run_with_scripted_replies(messenger)
+
+        expect(messenger.digest_reports).must_equal([
+          {"job" => "test ruby-3.2", "status" => "failed", "failures" => 3, "run_id" => "42"},
+          {"job" => "test ruby-3.3", "status" => "passed", "failures" => 0, "run_id" => "42"}
+        ])
+      end
+
+      it "marks the parent resolved when the messenger reports resolution" do
+        messenger = DigestMessengerDouble.new(resolved: true)
+        calls = run_with_scripted_replies(messenger)
+
+        body = JSON.parse(calls.last[:body])
+        expect(calls.last[:uri]).must_equal("https://slack.com/api/chat.update")
+        expect(body["metadata"]["event_payload"]["status"]).must_equal("resolved")
+      end
     end
 
     describe "#api_form_post" do

--- a/test/messenger_test.rb
+++ b/test/messenger_test.rb
@@ -16,7 +16,7 @@ describe ChatNotifier::Messenger do
       url
     end
   end
-  EnvironmentDouble = Struct.new(:ruby_version, :test_run_url)
+  EnvironmentDouble = Struct.new(:ruby_version, :test_run_url, :pull_request_ref)
   SummaryDouble = Struct.new(:failed_examples)
   LocationDouble = Struct.new(:location)
 
@@ -45,6 +45,20 @@ describe ChatNotifier::Messenger do
         messenger = ChatNotifier::Messenger.for(summary, repository: standin, environment: standin, app: standin)
         expect(messenger).must_be_instance_of(ChatNotifier::Messenger::Failure)
       end
+    end
+  end
+
+  describe "#thread_key" do
+    it "combines app and branch when there is no pull request ref" do
+      environment = EnvironmentDouble.new("Ruby 2.7.0", nil, nil)
+      messenger = ChatNotifier::Messenger.new(summary:, app:, repository:, environment:)
+      expect(messenger.thread_key).must_equal("app#test_branch")
+    end
+
+    it "combines app and pull request ref when present" do
+      environment = EnvironmentDouble.new("Ruby 2.7.0", nil, "fix/thing")
+      messenger = ChatNotifier::Messenger.new(summary:, app:, repository:, environment:)
+      expect(messenger.thread_key).must_equal("app#fix/thing")
     end
   end
 

--- a/test/messenger_test.rb
+++ b/test/messenger_test.rb
@@ -121,8 +121,23 @@ describe ChatNotifier::Messenger do
       refute digest.match?(/❌ 2\b/), "older-run failure count must not appear"
     end
 
-    it "converges: any ordering renders identical text" do
-      texts = reports.permutation.map { |ordering| messenger.digest(ordering) }
+    it "renders a writer-independent header without the writer's ruby version" do
+      digest = messenger.digest(reports)
+      expect(digest).must_match(/\A:boom: app abcdef123 in test_branch/)
+      refute digest.match?(/Ruby 2\.7\.0/), "the writing job's ruby version must not appear"
+    end
+
+    it "converges: any writer and any ordering renders identical text" do
+      writers = [
+        messenger,
+        ChatNotifier::Messenger.new(summary: SummaryDouble.new([]), app:, repository:,
+          environment: EnvironmentDouble.new("Ruby 3.3.0", "http://ci")),
+        ChatNotifier::Messenger::Failure.new(summary:, app:, repository:,
+          environment: EnvironmentDouble.new("Ruby 3.4.0", "http://ci"))
+      ]
+      texts = writers.flat_map do |writer|
+        reports.permutation.map { |ordering| writer.digest(ordering) }
+      end
       expect(texts.uniq.size).must_equal(1)
     end
 

--- a/test/messenger_test.rb
+++ b/test/messenger_test.rb
@@ -16,7 +16,7 @@ describe ChatNotifier::Messenger do
       url
     end
   end
-  EnvironmentDouble = Struct.new(:ruby_version, :test_run_url, :pull_request_ref, :job_identifier, :run_id)
+  EnvironmentDouble = Struct.new(:ruby_version, :test_run_url, :pull_request_ref, :job_identifier, :run_key)
   SummaryDouble = Struct.new(:failed_examples)
   LocationDouble = Struct.new(:location)
 
@@ -75,7 +75,9 @@ describe ChatNotifier::Messenger do
   end
 
   describe "#status_report" do
-    let(:environment) { EnvironmentDouble.new("Ruby 2.7.0", nil, nil, "test ruby-3.4", "42") }
+    # run_key (run id + attempt) fills the payload's run_id field so re-runs
+    # of the same GitHub run register as a newer run.
+    let(:environment) { EnvironmentDouble.new("Ruby 2.7.0", nil, nil, "test ruby-3.4", "42.1") }
 
     describe "when the run passes" do
       let(:summary) { SummaryDouble.new([]) }
@@ -83,7 +85,7 @@ describe ChatNotifier::Messenger do
       it "reports a passed status with no failures" do
         messenger = ChatNotifier::Messenger.new(summary:, app:, repository:, environment:)
         expect(messenger.status_report).must_equal(
-          {job: "test ruby-3.4", status: "passed", failures: 0, run_id: "42"}
+          {job: "test ruby-3.4", status: "passed", failures: 0, run_id: "42.1"}
         )
       end
     end
@@ -94,7 +96,7 @@ describe ChatNotifier::Messenger do
       it "reports a failed status with the failure count" do
         messenger = ChatNotifier::Messenger::Failure.new(summary:, app:, repository:, environment:)
         expect(messenger.status_report).must_equal(
-          {job: "test ruby-3.4", status: "failed", failures: 1, run_id: "42"}
+          {job: "test ruby-3.4", status: "failed", failures: 1, run_id: "42.1"}
         )
       end
     end
@@ -132,6 +134,15 @@ describe ChatNotifier::Messenger do
       assert messenger.resolved?(all_green), "latest run all green must be resolved"
       refute messenger.resolved?(reports), "latest run with failures must not be resolved"
       expect(messenger.digest(all_green)).must_match(/\A✅/)
+    end
+
+    it "resolves when a re-run attempt of the same run passes" do
+      rerun = [
+        {"job" => "test ruby-3.2", "status" => "failed", "failures" => 3, "run_id" => "43.1"},
+        {"job" => "test ruby-3.2", "status" => "passed", "failures" => 0, "run_id" => "43.2"}
+      ]
+      assert messenger.resolved?(rerun), "later attempt of the same run must win"
+      expect(messenger.digest(rerun)).must_match(/ruby-3\.2 ✅/)
     end
 
     it "treats reports without run_id as the oldest run" do

--- a/test/messenger_test.rb
+++ b/test/messenger_test.rb
@@ -16,7 +16,7 @@ describe ChatNotifier::Messenger do
       url
     end
   end
-  EnvironmentDouble = Struct.new(:ruby_version, :test_run_url, :pull_request_ref)
+  EnvironmentDouble = Struct.new(:ruby_version, :test_run_url, :pull_request_ref, :job_identifier, :run_id)
   SummaryDouble = Struct.new(:failed_examples)
   LocationDouble = Struct.new(:location)
 
@@ -71,6 +71,32 @@ describe ChatNotifier::Messenger do
     it "returns a success message" do
       messenger = ChatNotifier::Messenger.for(summary, repository:, environment:, app:)
       expect(messenger.message).must_equal(":thumbsup: app Ruby 2.7.0 abcdef123 is OK on branch https://github.com/test/test_repo/test_branch")
+    end
+  end
+
+  describe "#status_report" do
+    let(:environment) { EnvironmentDouble.new("Ruby 2.7.0", nil, nil, "test ruby-3.4", "42") }
+
+    describe "when the run passes" do
+      let(:summary) { SummaryDouble.new([]) }
+
+      it "reports a passed status with no failures" do
+        messenger = ChatNotifier::Messenger.new(summary:, app:, repository:, environment:)
+        expect(messenger.status_report).must_equal(
+          {job: "test ruby-3.4", status: "passed", failures: 0, run_id: "42"}
+        )
+      end
+    end
+
+    describe "when the run fails" do
+      let(:summary) { SummaryDouble.new([LocationDouble.new("spec/test_spec.rb:10")]) }
+
+      it "reports a failed status with the failure count" do
+        messenger = ChatNotifier::Messenger::Failure.new(summary:, app:, repository:, environment:)
+        expect(messenger.status_report).must_equal(
+          {job: "test ruby-3.4", status: "failed", failures: 1, run_id: "42"}
+        )
+      end
     end
   end
 

--- a/test/messenger_test.rb
+++ b/test/messenger_test.rb
@@ -100,6 +100,51 @@ describe ChatNotifier::Messenger do
     end
   end
 
+  describe "#digest" do
+    let(:reports) do
+      [
+        {"job" => "test ruby-3.2", "status" => "failed", "failures" => 12, "run_id" => "43"},
+        {"job" => "test ruby-3.3", "status" => "passed", "failures" => 0, "run_id" => "43"},
+        {"job" => "test ruby-3.2", "status" => "failed", "failures" => 2, "run_id" => "42"}
+      ]
+    end
+    let(:summary) { SummaryDouble.new([LocationDouble.new("spec/test_spec.rb:10")]) }
+    let(:environment) { EnvironmentDouble.new("Ruby 2.7.0", "http://ci") }
+    let(:messenger) { ChatNotifier::Messenger::Failure.new(summary:, app:, repository:, environment:) }
+
+    it "renders latest-run job statuses and ignores older runs" do
+      digest = messenger.digest(reports)
+      expect(digest).must_match(/ruby-3\.2 ❌ 12/)
+      expect(digest).must_match(/ruby-3\.3 ✅/)
+      refute digest.match?(/❌ 2\b/), "older-run failure count must not appear"
+    end
+
+    it "converges: any ordering renders identical text" do
+      texts = reports.permutation.map { |ordering| messenger.digest(ordering) }
+      expect(texts.uniq.size).must_equal(1)
+    end
+
+    it "reports resolved when the latest run is all green" do
+      all_green = [
+        {"job" => "test ruby-3.2", "status" => "passed", "failures" => 0, "run_id" => "44"},
+        {"job" => "test ruby-3.3", "status" => "failed", "failures" => 1, "run_id" => "43"}
+      ]
+      assert messenger.resolved?(all_green), "latest run all green must be resolved"
+      refute messenger.resolved?(reports), "latest run with failures must not be resolved"
+      expect(messenger.digest(all_green)).must_match(/\A✅/)
+    end
+
+    it "treats reports without run_id as the oldest run" do
+      mixed = [
+        {"job" => "legacy", "status" => "failed", "failures" => 5},
+        {"job" => "test ruby-3.2", "status" => "passed", "failures" => 0, "run_id" => "43"}
+      ]
+      digest = messenger.digest(mixed)
+      expect(digest).must_match(/ruby-3\.2 ✅/)
+      refute digest.match?(/legacy/), "nil run_id reports must lose to a numbered run"
+    end
+  end
+
   describe "Messenger::Failure" do
     let(:summary) { SummaryDouble.new([LocationDouble.new("spec/test_spec.rb:10")]) }
     let(:app) { AppDouble.new("test_branch", "abcdef123") }

--- a/test/support/thread_store_contract.rb
+++ b/test/support/thread_store_contract.rb
@@ -16,6 +16,11 @@ module ThreadStoreContract
         assert result.nil? || result.is_a?(ChatNotifier::ThreadStore::ThreadRef),
           "find must return nil or ThreadRef, got #{result.inspect}"
       end
+
+      it "find accepts an injectable process keyword" do
+        assert_includes store.method(:find).parameters, [:key, :process],
+          "find must accept a process: keyword so callers can inject transport"
+      end
     end
   end
 end

--- a/test/support/thread_store_contract.rb
+++ b/test/support/thread_store_contract.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Shared contract every ThreadStore implementation must satisfy.
+# Including specs must define `store` (a let) and `findable_key`
+# (a key the store may or may not resolve).
+module ThreadStoreContract
+  def self.included(base)
+    base.class_eval do
+      it "responds to find and record" do
+        assert_respond_to store, :find
+        assert_respond_to store, :record
+      end
+
+      it "find returns nil or a ThreadRef" do
+        result = store.find(findable_key)
+        assert result.nil? || result.is_a?(ChatNotifier::ThreadStore::ThreadRef),
+          "find must return nil or ThreadRef, got #{result.inspect}"
+      end
+    end
+  end
+end

--- a/test/test_environment/github_test.rb
+++ b/test/test_environment/github_test.rb
@@ -23,4 +23,16 @@ describe ChatNotifier::TestEnvironment::Github do
       expect(ChatNotifier::TestEnvironment::Github.new(settings: settings).run_id).must_equal("12345")
     end
   end
+
+  describe "#pull_request_ref" do
+    it "returns GITHUB_HEAD_REF when present" do
+      env = ChatNotifier::TestEnvironment::Github.new(settings: {"GITHUB_HEAD_REF" => "fix/thing"})
+      expect(env.pull_request_ref).must_equal("fix/thing")
+    end
+
+    it "returns nil when GITHUB_HEAD_REF is empty or missing" do
+      assert_nil ChatNotifier::TestEnvironment::Github.new(settings: {"GITHUB_HEAD_REF" => ""}).pull_request_ref
+      assert_nil ChatNotifier::TestEnvironment::Github.new(settings: {}).pull_request_ref
+    end
+  end
 end

--- a/test/test_environment/github_test.rb
+++ b/test/test_environment/github_test.rb
@@ -30,6 +30,27 @@ describe ChatNotifier::TestEnvironment::Github do
     end
   end
 
+  describe "#run_key" do
+    it "appends the run attempt so re-runs of the same run sort later" do
+      env = ChatNotifier::TestEnvironment::Github.new(
+        settings: {"NOTIFY_TEST_RUN_ID" => "43", "GITHUB_RUN_ATTEMPT" => "2"}
+      )
+      expect(env.run_key).must_equal("43.2")
+    end
+
+    it "falls back to the bare run id without an attempt" do
+      expect(ChatNotifier::TestEnvironment::Github.new(settings: {"NOTIFY_TEST_RUN_ID" => "43"}).run_key).must_equal("43")
+      assert_nil ChatNotifier::TestEnvironment::Github.new(settings: {"GITHUB_RUN_ATTEMPT" => "2"}).run_key
+    end
+
+    it "does not change test_run_url which needs the bare run id" do
+      env = ChatNotifier::TestEnvironment::Github.new(
+        settings: settings.merge("GITHUB_RUN_ATTEMPT" => "2")
+      )
+      expect(env.test_run_url).must_equal("https://github.com/test/test_repo/actions/runs/12345")
+    end
+  end
+
   describe "#job_identifier" do
     it "combines the job name and ruby version" do
       env = ChatNotifier::TestEnvironment::Github.new(settings: {"GITHUB_JOB" => "test"})

--- a/test/test_environment/github_test.rb
+++ b/test/test_environment/github_test.rb
@@ -22,6 +22,12 @@ describe ChatNotifier::TestEnvironment::Github do
     it "returns the NOTIFY_TEST_RUN_ID from settings" do
       expect(ChatNotifier::TestEnvironment::Github.new(settings: settings).run_id).must_equal("12345")
     end
+
+    it "prefers NOTIFY_TEST_RUN_ID and falls back to GITHUB_RUN_ID" do
+      expect(ChatNotifier::TestEnvironment::Github.new(settings: {"NOTIFY_TEST_RUN_ID" => "77", "GITHUB_RUN_ID" => "88"}).run_id).must_equal("77")
+      expect(ChatNotifier::TestEnvironment::Github.new(settings: {"GITHUB_RUN_ID" => "88"}).run_id).must_equal("88")
+      assert_nil ChatNotifier::TestEnvironment::Github.new(settings: {}).run_id
+    end
   end
 
   describe "#job_identifier" do

--- a/test/test_environment/github_test.rb
+++ b/test/test_environment/github_test.rb
@@ -24,6 +24,18 @@ describe ChatNotifier::TestEnvironment::Github do
     end
   end
 
+  describe "#job_identifier" do
+    it "combines the job name and ruby version" do
+      env = ChatNotifier::TestEnvironment::Github.new(settings: {"GITHUB_JOB" => "test"})
+      expect(env.job_identifier).must_equal("test ruby-#{RUBY_VERSION}")
+    end
+
+    it "prefers NOTIFY_JOB_NAME verbatim" do
+      env = ChatNotifier::TestEnvironment::Github.new(settings: {"NOTIFY_JOB_NAME" => "custom"})
+      expect(env.job_identifier).must_equal("custom")
+    end
+  end
+
   describe "#pull_request_ref" do
     it "returns GITHUB_HEAD_REF when present" do
       env = ChatNotifier::TestEnvironment::Github.new(settings: {"GITHUB_HEAD_REF" => "fix/thing"})

--- a/test/thread_store/null_test.rb
+++ b/test/thread_store/null_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "support/thread_store_contract"
+
+describe ChatNotifier::ThreadStore::Null do
+  let(:store) { ChatNotifier::ThreadStore::Null.new }
+  let(:findable_key) { "app#main" }
+
+  include ThreadStoreContract
+
+  it "never finds a thread" do
+    assert_nil store.find("app#main")
+  end
+
+  it "records without error" do
+    ref = ChatNotifier::ThreadStore::ThreadRef.new(ts: "1.2", status: "failing")
+    store.record("app#main", ref)
+  end
+end
+
+describe ChatNotifier::ThreadStore::ThreadRef do
+  it "is open unless resolved" do
+    assert ChatNotifier::ThreadStore::ThreadRef.new(ts: "1", status: "failing").open?
+    refute ChatNotifier::ThreadStore::ThreadRef.new(ts: "1", status: "resolved").open?
+  end
+end

--- a/test/thread_store/slack_metadata_test.rb
+++ b/test/thread_store/slack_metadata_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "support/thread_store_contract"
+
+FakeChatter = Struct.new(:channel, :responses) do
+  def api_form_post(url, params, process: nil)
+    (responses || []).shift || {}
+  end
+end
+
+describe ChatNotifier::ThreadStore::SlackMetadata do
+  let(:history) do
+    {"ok" => true, "messages" => [
+      {"ts" => "9.9", "text" => "unrelated"},
+      {"ts" => "5.5", "metadata" => {"event_type" => "chat_notifier_thread",
+                                     "event_payload" => {"key" => "app#main", "status" => "failing"}}},
+      {"ts" => "1.1", "metadata" => {"event_type" => "chat_notifier_thread",
+                                     "event_payload" => {"key" => "app#other", "status" => "failing"}}}
+    ]}
+  end
+  let(:chatter) { FakeChatter.new("#test", [history]) }
+  let(:store) { ChatNotifier::ThreadStore::SlackMetadata.new(chatter:) }
+  let(:findable_key) { "app#main" }
+
+  include ThreadStoreContract
+
+  it "finds the newest parent whose metadata matches the key" do
+    ref = store.find("app#main")
+    expect(ref.ts).must_equal("5.5")
+    expect(ref.status).must_equal("failing")
+  end
+
+  it "returns nil when no message matches" do
+    assert_nil store.find("app#unknown")
+  end
+
+  it "returns nil and logs when the API errors" do
+    chatter.responses = [{"ok" => false, "error" => "missing_scope"}]
+    logged = capture_logs { assert_nil store.find("app#main") }
+    expect(logged).must_match(/missing_scope/)
+  end
+end

--- a/test/thread_store/slack_metadata_test.rb
+++ b/test/thread_store/slack_metadata_test.rb
@@ -5,7 +5,12 @@ require "support/thread_store_contract"
 
 FakeChatter = Struct.new(:channel, :responses) do
   def api_form_post(url, params, process: nil)
+    calls << [url, params]
     (responses || []).shift || {}
+  end
+
+  def calls
+    @calls ||= []
   end
 end
 
@@ -15,6 +20,8 @@ describe ChatNotifier::ThreadStore::SlackMetadata do
       {"ts" => "9.9", "text" => "unrelated"},
       {"ts" => "5.5", "metadata" => {"event_type" => "chat_notifier_thread",
                                      "event_payload" => {"key" => "app#main", "status" => "failing"}}},
+      {"ts" => "2.2", "metadata" => {"event_type" => "chat_notifier_thread",
+                                     "event_payload" => {"key" => "app#main", "status" => "resolved"}}},
       {"ts" => "1.1", "metadata" => {"event_type" => "chat_notifier_thread",
                                      "event_payload" => {"key" => "app#other", "status" => "failing"}}}
     ]}
@@ -29,6 +36,13 @@ describe ChatNotifier::ThreadStore::SlackMetadata do
     ref = store.find("app#main")
     expect(ref.ts).must_equal("5.5")
     expect(ref.status).must_equal("failing")
+  end
+
+  it "requests channel history with metadata included" do
+    store.find("app#main")
+    url, params = chatter.calls.last
+    expect(url).must_equal("https://slack.com/api/conversations.history")
+    expect(params).must_equal({channel: "#test", limit: 200, include_all_metadata: true})
   end
 
   it "returns nil when no message matches" do

--- a/test/thread_store/slack_metadata_test.rb
+++ b/test/thread_store/slack_metadata_test.rb
@@ -5,7 +5,7 @@ require "support/thread_store_contract"
 
 FakeChatter = Struct.new(:channel, :responses) do
   def api_form_post(url, params, process: nil)
-    calls << [url, params]
+    calls << [url, params, process]
     (responses || []).shift || {}
   end
 
@@ -47,6 +47,17 @@ describe ChatNotifier::ThreadStore::SlackMetadata do
 
   it "returns nil when no message matches" do
     assert_nil store.find("app#unknown")
+  end
+
+  it "passes an injected process through to the chatter" do
+    probe = ->(*) {}
+    store.find("app#main", process: probe)
+    expect(chatter.calls.last.last).must_equal(probe)
+  end
+
+  it "uses the chatter's default transport when no process is given" do
+    store.find("app#main")
+    assert_nil chatter.calls.last.last
   end
 
   it "returns nil and logs when the API errors" do

--- a/test/thread_store/slack_metadata_test.rb
+++ b/test/thread_store/slack_metadata_test.rb
@@ -65,4 +65,13 @@ describe ChatNotifier::ThreadStore::SlackMetadata do
     logged = capture_logs { assert_nil store.find("app#main") }
     expect(logged).must_match(/missing_scope/)
   end
+
+  it "returns nil and logs when the transport raises" do
+    def chatter.api_form_post(*, **)
+      raise SocketError, "getaddrinfo: nodename nor servname provided"
+    end
+
+    logged = capture_logs { assert_nil store.find("app#main") }
+    expect(logged).must_match(/getaddrinfo/)
+  end
 end


### PR DESCRIPTION
## Summary

Implements Phase 1's remaining threading work: **one Slack thread per breakage episode** on a branch/PR, shared across parallel CI jobs, with the parent message maintained as a **live status digest** that resolves automatically when the branch goes green.

Design doc and implementation plan were developed and reviewed incrementally; every change was test-driven.

### How it works

- **`ThreadStore` strategy** (DI, like every collaborator): maps a thread key (`app#pr-ref-or-branch`) to a thread. `Null` (default, zero-config) and `SlackMetadata` — which uses Slack itself as the store: parents carry message metadata, jobs find the episode via `conversations.history`. No shared storage or infrastructure.
- **Episodes**: a resolved thread is treated as a miss — break → fix → break again yields two clean threads. Matrix jobs join the same episode instead of posting three parents.
- **Live digest**: each job appends a machine-readable status reply; the parent is recomputed from the full thread log via `chat.update` (`test ruby-3.2 ❌ 12 · test ruby-3.3 ✅`). Concurrent writers converge — the digest is a pure function of the reports (property-tested across writers × orderings).
- **Resolution**: passing runs post nothing unless they close a known open episode (noise discipline preserved). `GITHUB_RUN_ATTEMPT` is folded into run keys so "Re-run failed jobs" supersedes earlier attempts.
- **Degradation ladder**: missing scopes, non-member bot, channel-name-instead-of-ID, transport errors, rate limits — every failure logs and lands on pre-feature behavior (per-job threads). Verified live against a real workspace.

### Also fixes a silent production bug

`Messenger` delegates `branch`/`sha` to `app`, which `ChatNotifier.call` passed as a plain String — every real notification raised `NoMethodError`, swallowed by the rescue-and-log in `call`. New `ChatNotifier::App` value object resolves branch/sha from `NOTIFY_BRANCH`/`GITHUB_*` env or git, with a regression test through the real factories.

### Configuration

| | |
|---|---|
| `NOTIFY_THREAD_STORE=none` | opt out of episode threading |
| `NOTIFY_JOB_NAME` | job identity override (default `GITHUB_JOB` + ruby version) |
| `ChatNotifier.call(thread_store:)` | inject a custom store (two-method duck type + shared contract test) |
| New bot scopes | `channels:history` (+ `groups:history` for private channels); channel **ID** required |

## Test plan

- [x] `rake test` — 108 runs, 209 assertions, 0 failures (67 new tests)
- [x] `standardrb` — no new offenses (7 pre-existing on main untouched)
- [x] `rake reissue:preview` — 0.4.0, changelog entries from commit trailers
- [x] Live debug session against a real Slack workspace: episode creation, cross-job thread joining, digest updates, resolution, and the missing-scope/channel-name degradation paths