### PR TITLE
Fold status reports that share a job identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,15 @@ back to its own thread.
 Caveats: verbose mode (`NOTIFIER_VERBOSE`) posts plain messages and bypasses
 episode resolution, and a thread store passed programmatically
 (`ChatNotifier.call(thread_store: ...)`) takes precedence over
-`NOTIFY_THREAD_STORE=none`. A single CI job running both RSpec and Minitest
-posts two status reports under the same job identity and only the earliest per
-run counts in the digest — set `NOTIFY_JOB_NAME` per framework to disambiguate.
+`NOTIFY_THREAD_STORE=none`.
+
+Reporting more than once under one job identity is safe. Parallel runners
+(`parallel_tests`, Knapsack) spawn a process per worker, each with its own
+formatter, and a single job running both RSpec and Minitest posts twice.
+Reports sharing a job name are folded per run — failure counts sum and any
+failure fails the job — so the digest keeps one line per job and a worker that
+passed cannot resolve the episode its sibling opened. Set `NOTIFY_JOB_NAME` if
+you would rather they appear as separate lines.
 
 ### Debug your Slack setup
 

--- a/lib/chat_notifier/messenger.rb
+++ b/lib/chat_notifier/messenger.rb
@@ -144,9 +144,23 @@ module ChatNotifier
       latest_id = grouped.keys.max_by { |id| [id.length, id] }
       # [length, value] orders numeric strings correctly ("9" < "10") and
       # sorts nil run_ids ("") as the oldest run.
-      # conversations.replies returns replies oldest-first, so uniq keeps the
-      # earliest status per job per run; jobs post once per run, so it's fine.
-      grouped.fetch(latest_id, []).uniq { |report| report["job"] }
+      grouped.fetch(latest_id, []).group_by { |report| report["job"] }.map do |job, group|
+        fold(job, group)
+      end
+    end
+
+    # A job identity can report more than once per run: parallel test runners
+    # (parallel_tests, Knapsack) spawn a process per worker, each with its own
+    # formatter, all sharing one job name. Any worker failing fails the job, so
+    # fold the group rather than keeping whichever arrived first — otherwise a
+    # worker that passed silently resolves the episode its sibling just opened.
+    # Commutative, so every writer converges on the same digest.
+    def fold(job, group)
+      {
+        "job" => job,
+        "status" => (group.any? { |report| report["status"] != "passed" }) ? "failed" : "passed",
+        "failures" => group.sum { |report| report["failures"].to_i }
+      }
     end
   end
 end

--- a/test/messenger_test.rb
+++ b/test/messenger_test.rb
@@ -160,6 +160,27 @@ describe ChatNotifier::Messenger do
       expect(messenger.digest(rerun)).must_match(/ruby-3\.2 ✅/)
     end
 
+    it "fails a job when any of its workers failed, whatever the reporting order" do
+      workers = [
+        {"job" => "rspec", "status" => "passed", "failures" => 0, "run_id" => "43"},
+        {"job" => "rspec", "status" => "failed", "failures" => 4, "run_id" => "43"},
+        {"job" => "rspec", "status" => "failed", "failures" => 3, "run_id" => "43"}
+      ]
+      workers.permutation.each do |ordering|
+        refute messenger.resolved?(ordering), "a passing worker must not resolve its siblings' failures"
+        expect(messenger.digest(ordering)).must_match(/rspec ❌ 7/)
+      end
+    end
+
+    it "resolves a job only when every worker passed" do
+      workers = [
+        {"job" => "rspec", "status" => "passed", "failures" => 0, "run_id" => "43"},
+        {"job" => "rspec", "status" => "passed", "failures" => 0, "run_id" => "43"}
+      ]
+      assert messenger.resolved?(workers)
+      expect(messenger.digest(workers)).must_match(/rspec ✅/)
+    end
+
     it "treats reports without run_id as the oldest run" do
       mixed = [
         {"job" => "legacy", "status" => "failed", "failures" => 5},


### PR DESCRIPTION
## Why

The episode digest assumed one status report per job per run — `latest_run` deduped with `uniq { |report| report["job"] }`, keeping whichever arrived first, and the comment said so: "jobs post once per run, so it's fine."

That holds for matrix jobs. It does not hold for parallel runners. `parallel_tests` spawns a process per worker, each loading the test helper and registering its own formatter, so one job identity reports N times per run.

The consequence is a false green. A failing worker posts its parent, then its file batches, then its status — a window of a second or two. Any passing worker landing in that window calls `resolve_episode`, finds the episode open, and posts `passed` first. `uniq` keeps it, and every later `update_parent` recomputes to the same wrong answer. The parent sits at ✅ resolved with real failures unread in the thread.

Qualify hits this directly: `rake parallel:spec`, one worker per vCPU.

## Summary

- Reports sharing a job name fold per run instead of first-one-wins: failure counts sum, any failure fails the job. Commutative, so the digest still converges regardless of which worker writes last.
- Because the failing worker always calls `update_parent` after posting its own status, a transient ✅ from a passing sibling now self-repairs.
- README: the old caveat prescribed `NOTIFY_JOB_NAME` as the workaround for double-reporting. It is now an option for splitting jobs into separate digest lines, not a correctness requirement.